### PR TITLE
[Rust code] Prefer `expect` instead of `unwrap` in many cases

### DIFF
--- a/python/optify/Cargo.lock
+++ b/python/optify/Cargo.lock
@@ -383,9 +383,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.23.4"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57fe09249128b3173d092de9523eaa75136bf7ba85e0d69eca241c7939c933cc"
+checksum = "17da310086b068fbdcefbba30aeb3721d5bb9af8db4987d6735b2183ca567229"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -401,9 +401,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.23.4"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd3927b5a78757a0d71aa9dff669f903b1eb64b54142a9bd9f757f8fde65fd7"
+checksum = "e27165889bd793000a098bb966adc4300c312497ea25cf7a690a9f0ac5aa5fc1"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -411,9 +411,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.23.4"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dab6bb2102bd8f991e7749f130a70d05dd557613e39ed2deeee8e9ca0c4d548d"
+checksum = "05280526e1dbf6b420062f3ef228b78c0c54ba94e157f5cb724a609d0f2faabc"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -421,9 +421,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.23.4"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91871864b353fd5ffcb3f91f2f703a22a9797c91b9ab497b1acac7b07ae509c7"
+checksum = "5c3ce5686aa4d3f63359a5100c62a127c9f15e8398e5fdeb5deef1fed5cd5f44"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -433,9 +433,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.23.4"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43abc3b80bc20f3facd86cd3c60beed58c3e2aa26213f3cda368de39c60a27e4"
+checksum = "f4cf6faa0cbfb0ed08e89beb8103ae9724eb4750e3a78084ba4017cbe94f3855"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -556,9 +556,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.16"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
 
 [[package]]
 name = "thiserror"

--- a/python/optify/Cargo.lock
+++ b/python/optify/Cargo.lock
@@ -287,7 +287,7 @@ checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
 name = "optify"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "config",
  "serde",
@@ -299,7 +299,7 @@ dependencies = [
 
 [[package]]
 name = "optify-python"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "optify",
  "pyo3",
@@ -513,9 +513,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.138"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",

--- a/python/optify/Cargo.lock
+++ b/python/optify/Cargo.lock
@@ -287,7 +287,7 @@ checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
 name = "optify"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "config",
  "serde",

--- a/python/optify/Cargo.toml
+++ b/python/optify/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "optify-python"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 description = "Simplifies getting the right configuration options for a process using pre-loaded configurations from files (JSON, YAML, etc.) to manage options for experiments or flights. This library is mainly made to support building implementations for other languages such as Node.js, Python, and Ruby. It is not meant to be consumed directly yet."

--- a/python/optify/Cargo.toml
+++ b/python/optify/Cargo.toml
@@ -15,4 +15,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 optify = { path = "../../rust/optify", version = "0.6.1" }
-pyo3 = "0.23.3"
+pyo3 = "0.24.1"

--- a/python/optify/Cargo.toml
+++ b/python/optify/Cargo.toml
@@ -14,5 +14,5 @@ name = "optify"
 crate-type = ["cdylib"]
 
 [dependencies]
-optify = { path = "../../rust/optify", version = "0.6.0" }
+optify = { path = "../../rust/optify", version = "0.6.1" }
 pyo3 = "0.23.3"

--- a/python/optify/pyproject.toml
+++ b/python/optify/pyproject.toml
@@ -26,11 +26,11 @@ build-backend = "maturin"
 
 [package]
 name = "optify"
-version = "0.1.1"
+version = "0.1.2"
 
 [tool.poetry]
 name = "optify"
-version = "0.1.1"
+version = "0.1.2"
 description = "Simplifies getting the right configuration options for a process using pre-loaded configurations from files to manage options for experiments or flights."
 authors = ["Justin D. Harris"]
 maintainers = ["Justin D. Harris"]

--- a/python/optify/src/lib.rs
+++ b/python/optify/src/lib.rs
@@ -17,7 +17,10 @@ impl PyOptionsProvider {
     }
 
     fn get_options_json(&self, key: &str, feature_names: Vec<String>) -> String {
-        self.0.get_options(key, &feature_names).unwrap().to_string()
+        self.0
+            .get_options(key, &feature_names)
+            .expect("Failed to get options")
+            .to_string()
     }
 }
 
@@ -30,13 +33,19 @@ impl PyOptionsProviderBuilder {
 
     fn add_directory(&mut self, directory: &str) -> Self {
         let path = std::path::Path::new(&directory);
-        self.0.add_directory(path).unwrap();
+        self.0
+            .add_directory(path)
+            .expect("Failed to add the directory");
         // TODO Try to avoid cloning
         Self(self.0.clone())
     }
 
     fn build(&mut self) -> PyOptionsProvider {
-        PyOptionsProvider(self.0.build().unwrap())
+        PyOptionsProvider(
+            self.0
+                .build()
+                .expect("Failed to build the options provider"),
+        )
     }
 }
 

--- a/python/optify/tests/test_provider.py
+++ b/python/optify/tests/test_provider.py
@@ -1,6 +1,7 @@
 import os
 import json
 from pathlib import Path
+import sys
 
 from optify import OptionsProviderBuilder
 
@@ -12,3 +13,11 @@ def test_features():
     features = provider.features()
     features.sort()
     assert features == ['A_with_comments', 'feature_A', 'feature_B/initial']
+
+    try:
+        provider.get_options_json('key', ['A'])
+        assert False, "Should have raised an error"
+    except:
+        # Can't get pyo3_runtime.PanicException because can't import it and catching `Exception` doesn't work either.
+        e = sys.exc_info()[1]
+        assert str(e) == "Failed to get options: \"configuration property \\\"key\\\" not found\""

--- a/ruby/optify/ext/optify_ruby/Cargo.toml
+++ b/ruby/optify/ext/optify_ruby/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "optify_ruby"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 
 description = "optify bindings for Ruby"
@@ -21,6 +21,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 magnus = "0.7.1"
-optify = { path = "../../../../rust/optify", version = "0.6.0" }
+optify = { path = "../../../../rust/optify", version = "0.6.1" }
 rb-sys = { version = "*", default-features = false, features = ["ruby-static"] }
 serde_json = "1.0.140"

--- a/ruby/optify/ext/optify_ruby/src/lib.rs
+++ b/ruby/optify/ext/optify_ruby/src/lib.rs
@@ -44,7 +44,7 @@ impl WrappedOptionsProvider {
             .0
             .borrow()
             .get_all_options(&feature_names, &None, &_preferences)
-            .unwrap()
+            .expect("Failed to get all options")
             .to_string())
     }
 
@@ -77,7 +77,7 @@ impl WrappedOptionsProvider {
         self.0
             .borrow()
             .get_options_with_preferences(&key, &feature_names, &None, &None)
-            .unwrap()
+            .expect("Failed to get options")
             .to_string()
     }
 
@@ -91,7 +91,7 @@ impl WrappedOptionsProvider {
         self.0
             .borrow()
             .get_options_with_preferences(&key, &feature_names, &None, &_preferences)
-            .unwrap()
+            .expect("Failed to get options with preferences")
             .to_string()
     }
 }
@@ -116,12 +116,20 @@ impl WrappedOptionsProviderBuilder {
         directory: String,
     ) -> Result<WrappedOptionsProviderBuilder, magnus::Error> {
         let path = std::path::Path::new(&directory);
-        self.0.borrow_mut().add_directory(path).unwrap();
+        self.0
+            .borrow_mut()
+            .add_directory(path)
+            .expect("Failed to add the directory");
         Ok(self.clone())
     }
 
     fn build(&self) -> WrappedOptionsProvider {
-        WrappedOptionsProvider(RefCell::new(self.0.borrow_mut().build().unwrap()))
+        WrappedOptionsProvider(RefCell::new(
+            self.0
+                .borrow_mut()
+                .build()
+                .expect("Failed to build the OptionsProvider"),
+        ))
     }
 }
 

--- a/ruby/optify/optify.gemspec
+++ b/ruby/optify/optify.gemspec
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-VERSION = '0.8.0'
+VERSION = '0.8.1'
 
 Gem::Specification.new do |spec|
   spec.name = 'optify-config'

--- a/rust/optify/Cargo.toml
+++ b/rust/optify/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "optify"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 
 description = "Simplifies getting the right configuration options for a process using pre-loaded configurations from files (JSON, YAML, etc.) to manage options for experiments or flights. This library is mainly made to support building implementations for other languages such as Node.js, Python, and Ruby. It is not meant to be consumed directly yet."

--- a/rust/optify/src/builder.rs
+++ b/rust/optify/src/builder.rs
@@ -111,7 +111,7 @@ fn resolve_imports(
     let source = sources.get(canonical_feature_name).unwrap();
     config_builder = config_builder.add_source(source.clone());
 
-    // We have the configuration, build it and store it.
+    // Build the configuration and store it.
     match config_builder.build() {
         Ok(new_config) => {
             // Convert to something that can be inserted as a source.
@@ -123,8 +123,9 @@ fn resolve_imports(
                 ))
                 }
             };
-            let options_as_json: serde_json::Value =
-                options_as_config_value.try_deserialize().unwrap();
+            let options_as_json: serde_json::Value = options_as_config_value
+                .try_deserialize()
+                .expect("Error deserializing the configuration as JSON.");
             let options_as_json_str = serde_json::to_string(&options_as_json).unwrap();
             let source = config::File::from_str(&options_as_json_str, config::FileFormat::Json);
             sources.insert(canonical_feature_name.to_owned(), source);

--- a/rust/optify/tests/test_builder.rs
+++ b/rust/optify/tests/test_builder.rs
@@ -1,42 +1,44 @@
 use optify::builder::OptionsProviderBuilder;
 
 #[test]
-fn test_builder_circular_imports() {
+fn test_builder_circular_imports() -> Result<(), Box<dyn std::error::Error>> {
     let path = std::path::Path::new("tests/circular_imports");
     let mut builder = OptionsProviderBuilder::new();
-    builder.add_directory(path).unwrap();
+    builder.add_directory(path)?;
     match builder.build() {
         Ok(_) => panic!("Expected an error."),
         Err(e) => {
             // Just use a big regex instead of being consistent slowing down the builder to keep ordered maps or sets.
             let pattern = r#"Error when resolving imports for 'a': Cycle detected with import 'b'. The features in the path \(not in order\): \{"a", "b"}|Error when resolving imports for 'a': Cycle detected with import 'b'. The features in the path \(not in order\): \{"b", "a"}|Error when resolving imports for 'b': Cycle detected with import 'a'. The features in the path \(not in order\): \{"a", "b"}|Error when resolving imports for 'b': Cycle detected with import 'a'. The features in the path \(not in order\): \{"b", "a"}"#;
             assert!(
-                regex::Regex::new(pattern).unwrap().is_match(&e),
+                regex::Regex::new(pattern)?.is_match(&e),
                 "Got: {e}\nExpected pattern: {pattern}",
             );
+            Ok(())
         }
     }
 }
 
 #[test]
-fn test_builder_cycle_in_imports() {
+fn test_builder_cycle_in_imports() -> Result<(), Box<dyn std::error::Error>> {
     let path = std::path::Path::new("tests/cycle_in_imports");
     let mut builder = OptionsProviderBuilder::new();
-    builder.add_directory(path).unwrap();
+    builder.add_directory(path)?;
     match builder.build() {
         Ok(_) => panic!("Expected an error."),
         Err(e) => {
             let pattern = r#"Error when resolving imports for '[abc]': Cycle detected with import '[abc]'. The features in the path \(not in order\): \{("([abc]|start)", ){2,3}"([abc]|start)"}"#;
             assert!(
-                regex::Regex::new(pattern).unwrap().is_match(&e),
+                regex::Regex::new(pattern)?.is_match(&e),
                 "Got: {e}\nExpected pattern: {pattern}",
             );
+            Ok(())
         }
     }
 }
 
 #[test]
-fn test_builder_duplicate_alias() {
+fn test_builder_duplicate_alias() -> Result<(), Box<dyn std::error::Error>> {
     let path = std::path::Path::new("tests/duplicate_alias");
     let mut builder = OptionsProviderBuilder::new();
     match builder.add_directory(path) {
@@ -44,9 +46,10 @@ fn test_builder_duplicate_alias() {
         Err(e) => {
             let pattern = r#"The alias 'b' for canonical feature name 'a' is already mapped to 'b'\.|The alias 'b' for canonical feature name 'b' is already mapped to 'a'\."#;
             assert!(
-                regex::Regex::new(pattern).unwrap().is_match(&e),
+                regex::Regex::new(pattern)?.is_match(&e),
                 "Got: {e}\nExpected pattern: {pattern}",
             );
+            Ok(())
         }
     }
 }


### PR DESCRIPTION
`unwrap` is fine when an error should never happen. For some cases, such as wrong input like an invalid key or feature, we should ensure that we have clear error messages.