### PR TITLE
[Rust code] Follow `expect` message style guidelines

### DIFF
--- a/python/optify/src/lib.rs
+++ b/python/optify/src/lib.rs
@@ -19,7 +19,7 @@ impl PyOptionsProvider {
     fn get_options_json(&self, key: &str, feature_names: Vec<String>) -> String {
         self.0
             .get_options(key, &feature_names)
-            .expect("Failed to get options")
+            .expect("key and feature names should be valid")
             .to_string()
     }
 }
@@ -35,7 +35,7 @@ impl PyOptionsProviderBuilder {
         let path = std::path::Path::new(&directory);
         self.0
             .add_directory(path)
-            .expect("Failed to add the directory");
+            .expect("directory contents should be valid");
         // TODO Try to avoid cloning
         Self(self.0.clone())
     }
@@ -44,7 +44,7 @@ impl PyOptionsProviderBuilder {
         PyOptionsProvider(
             self.0
                 .build()
-                .expect("Failed to build the options provider"),
+                .expect("OptionsProvider should be built successfully"),
         )
     }
 }

--- a/python/optify/tests/test_provider.py
+++ b/python/optify/tests/test_provider.py
@@ -20,4 +20,4 @@ def test_features():
     except:
         # Can't get pyo3_runtime.PanicException because can't import it and catching `Exception` doesn't work either.
         e = sys.exc_info()[1]
-        assert str(e) == "Failed to get options: \"configuration property \\\"key\\\" not found\""
+        assert str(e) == "key and feature names should be valid: \"configuration property \\\"key\\\" not found\""

--- a/python/optify/tests/test_provider.py
+++ b/python/optify/tests/test_provider.py
@@ -1,9 +1,7 @@
-import os
-import json
 from pathlib import Path
-import sys
 
 from optify import OptionsProviderBuilder
+
 
 def test_features():
     test_suites_dir = (Path(__file__) / '../../../../tests/test_suites').resolve()
@@ -17,7 +15,5 @@ def test_features():
     try:
         provider.get_options_json('key', ['A'])
         assert False, "Should have raised an error"
-    except:
-        # Can't get pyo3_runtime.PanicException because can't import it and catching `Exception` doesn't work either.
-        e = sys.exc_info()[1]
+    except BaseException as e:
         assert str(e) == "key and feature names should be valid: \"configuration property \\\"key\\\" not found\""

--- a/ruby/optify/ext/optify_ruby/src/lib.rs
+++ b/ruby/optify/ext/optify_ruby/src/lib.rs
@@ -44,7 +44,7 @@ impl WrappedOptionsProvider {
             .0
             .borrow()
             .get_all_options(&feature_names, &None, &_preferences)
-            .expect("Failed to get all options")
+            .expect("features and preferences should be valid")
             .to_string())
     }
 
@@ -77,7 +77,7 @@ impl WrappedOptionsProvider {
         self.0
             .borrow()
             .get_options_with_preferences(&key, &feature_names, &None, &None)
-            .expect("Failed to get options")
+            .expect("key and feature names should be valid")
             .to_string()
     }
 
@@ -91,7 +91,7 @@ impl WrappedOptionsProvider {
         self.0
             .borrow()
             .get_options_with_preferences(&key, &feature_names, &None, &_preferences)
-            .expect("Failed to get options with preferences")
+            .expect("key, feature names, and preferences should be valid")
             .to_string()
     }
 }
@@ -119,7 +119,7 @@ impl WrappedOptionsProviderBuilder {
         self.0
             .borrow_mut()
             .add_directory(path)
-            .expect("Failed to add the directory");
+            .expect("directory contents should be valid");
         Ok(self.clone())
     }
 
@@ -128,7 +128,7 @@ impl WrappedOptionsProviderBuilder {
             self.0
                 .borrow_mut()
                 .build()
-                .expect("Failed to build the OptionsProvider"),
+                .expect("OptionsProvider should be built successfully"),
         ))
     }
 }

--- a/rust/optify/src/builder.rs
+++ b/rust/optify/src/builder.rs
@@ -125,7 +125,7 @@ fn resolve_imports(
             };
             let options_as_json: serde_json::Value = options_as_config_value
                 .try_deserialize()
-                .expect("Error deserializing the configuration as JSON.");
+                .expect("configuration should be deserializable to JSON");
             let options_as_json_str = serde_json::to_string(&options_as_json).unwrap();
             let source = config::File::from_str(&options_as_json_str, config::FileFormat::Json);
             sources.insert(canonical_feature_name.to_owned(), source);


### PR DESCRIPTION
Follow up for https://github.com/juharris/optify/pull/27#discussion_r2027201386

See https://doc.rust-lang.org/std/option/enum.Option.html#recommended-message-style

Not gonna bother bumping the version for this small change.