### PR TITLE
[watcher] Ignore reads and modifying metadata

### DIFF
--- a/python/optify/Cargo.lock
+++ b/python/optify/Cargo.lock
@@ -461,7 +461,7 @@ checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
 name = "optify"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "config",
  "notify",

--- a/python/optify/Cargo.toml
+++ b/python/optify/Cargo.toml
@@ -14,5 +14,5 @@ name = "optify"
 crate-type = ["cdylib"]
 
 [dependencies]
-optify = { path = "../../rust/optify", version = "0.8.0" }
+optify = { path = "../../rust/optify", version = "0.8.1" }
 pyo3 = "0.24.1"

--- a/ruby/optify/ext/optify_ruby/Cargo.toml
+++ b/ruby/optify/ext/optify_ruby/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "optify_ruby"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 
 description = "optify bindings for Ruby"
@@ -21,6 +21,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 magnus = "0.7.1"
-optify = { path = "../../../../rust/optify", version = "0.8.0" }
+optify = { path = "../../../../rust/optify", version = "0.8.1" }
 rb-sys = { version = "*", default-features = false, features = ["ruby-static"] }
 serde_json = "1.0.140"

--- a/ruby/optify/optify.gemspec
+++ b/ruby/optify/optify.gemspec
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-VERSION = '1.2.1'
+VERSION = '1.2.2'
 
 Gem::Specification.new do |spec|
   spec.name = 'optify-config'

--- a/rust/optify/Cargo.toml
+++ b/rust/optify/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "optify"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 
 description = "Simplifies getting the right configuration options for a process using pre-loaded configurations from files (JSON, YAML, etc.) to manage options for experiments or flights. This library is mainly made to support building implementations for other languages such as Node.js, Python, and Ruby. It is not meant to be consumed directly yet."

--- a/rust/optify/src/provider/watcher.rs
+++ b/rust/optify/src/provider/watcher.rs
@@ -9,6 +9,9 @@ use crate::provider::{
 };
 use crate::schema::metadata::OptionsMetadata;
 
+/// The duration to wait before triggering a rebuild after file changes.
+pub const DEFAULT_DEBOUNCE_DURATION: std::time::Duration = std::time::Duration::from_secs(1);
+
 /// A registry which changes the underlying when files are changed.
 /// This is mainly meant to use for local development.
 ///
@@ -31,7 +34,7 @@ impl OptionsWatcher {
         // Set up the watcher before building in case the files change before building.
         let (tx, rx) = channel();
         let mut debouncer_watcher = new_debouncer(
-            std::time::Duration::from_secs(1),
+            DEFAULT_DEBOUNCE_DURATION,
             None,
             move |result: DebounceEventResult| match result {
                 Ok(events) => {

--- a/rust/optify/tests/test_watchable_builder.rs
+++ b/rust/optify/tests/test_watchable_builder.rs
@@ -148,7 +148,11 @@ fn test_watchable_builder_read_file() -> Result<(), Box<dyn std::error::Error>> 
     assert_eq!(file_content, "{\"options\":{\"test\":42}}");
     thread::sleep(DEFAULT_DEBOUNCE_DURATION + Duration::from_millis(700));
 
-    assert_eq!(provider.last_modified(), last_modified);
+    assert_eq!(
+        provider.last_modified(),
+        last_modified,
+        "The last modified time should not have changed because we did not modify the file contents."
+    );
 
     Ok(())
 }

--- a/rust/optify/tests/test_watchable_builder.rs
+++ b/rust/optify/tests/test_watchable_builder.rs
@@ -4,7 +4,7 @@ use optify::provider::DEFAULT_DEBOUNCE_DURATION;
 use std::fs::File;
 use std::io::Write;
 use std::thread;
-use std::time::{Duration, SystemTime};
+use std::time::Duration;
 
 const SLEEP_TIME: u64 = 50;
 
@@ -143,7 +143,7 @@ fn test_watchable_builder_read_file() -> Result<(), Box<dyn std::error::Error>> 
     let options = provider.get_options("test", &["test"])?;
     assert_eq!(options.as_i64(), Some(42));
 
-    File::open(&options_file)?.set_modified(SystemTime::now())?;
+    File::open(&options_file)?;
     let file_content = std::fs::read_to_string(&options_file)?;
     assert_eq!(file_content, "{\"options\":{\"test\":42}}");
     thread::sleep(DEFAULT_DEBOUNCE_DURATION + Duration::from_millis(700));

--- a/rust/optify/tests/test_watchable_builder.rs
+++ b/rust/optify/tests/test_watchable_builder.rs
@@ -143,7 +143,6 @@ fn test_watchable_builder_read_file() -> Result<(), Box<dyn std::error::Error>> 
     let options = provider.get_options("test", &["test"])?;
     assert_eq!(options.as_i64(), Some(42));
 
-    File::open(&options_file)?;
     let file_content = std::fs::read_to_string(&options_file)?;
     assert_eq!(file_content, "{\"options\":{\"test\":42}}");
     thread::sleep(DEFAULT_DEBOUNCE_DURATION + Duration::from_millis(700));

--- a/rust/optify/tests/test_watchable_builder.rs
+++ b/rust/optify/tests/test_watchable_builder.rs
@@ -1,6 +1,5 @@
 use optify::builder::{OptionsRegistryBuilder, OptionsWatcherBuilder};
 use optify::provider::OptionsRegistry;
-use optify::provider::DEFAULT_DEBOUNCE_DURATION;
 use std::fs::File;
 use std::io::Write;
 use std::thread;
@@ -121,39 +120,6 @@ fn test_watchable_builder_multiple_directories() -> Result<(), Box<dyn std::erro
         options1.err().unwrap(),
         "The given feature \"test1\" was not found."
     );
-
-    Ok(())
-}
-
-#[test]
-fn test_watchable_builder_read_file() -> Result<(), Box<dyn std::error::Error>> {
-    let temp_dir = tempfile::tempdir()?;
-    let test_dir = temp_dir.path();
-
-    let options_file = test_dir.join("test.json");
-    let mut file = File::create(&options_file)?;
-    file.write_all(b"{\"options\":{\"test\":42}}")?;
-
-    let mut builder = OptionsWatcherBuilder::new();
-    builder.add_directory(test_dir)?;
-    let provider = builder.build()?;
-
-    let last_modified = provider.last_modified();
-
-    let options = provider.get_options("test", &["test"])?;
-    assert_eq!(options.as_i64(), Some(42));
-
-    File::open(&options_file)?;
-    thread::sleep(DEFAULT_DEBOUNCE_DURATION + Duration::from_millis(700));
-
-    assert_eq!(
-        provider.last_modified(),
-        last_modified,
-        "The last modified time should not have changed because we did not modify the file contents."
-    );
-
-    let file_content = std::fs::read_to_string(&options_file)?;
-    assert_eq!(file_content, "{\"options\":{\"test\":42}}");
 
     Ok(())
 }

--- a/rust/optify/tests/test_watchable_builder.rs
+++ b/rust/optify/tests/test_watchable_builder.rs
@@ -143,8 +143,7 @@ fn test_watchable_builder_read_file() -> Result<(), Box<dyn std::error::Error>> 
     let options = provider.get_options("test", &["test"])?;
     assert_eq!(options.as_i64(), Some(42));
 
-    let file_content = std::fs::read_to_string(&options_file)?;
-    assert_eq!(file_content, "{\"options\":{\"test\":42}}");
+    File::open(&options_file)?;
     thread::sleep(DEFAULT_DEBOUNCE_DURATION + Duration::from_millis(700));
 
     assert_eq!(
@@ -152,6 +151,9 @@ fn test_watchable_builder_read_file() -> Result<(), Box<dyn std::error::Error>> 
         last_modified,
         "The last modified time should not have changed because we did not modify the file contents."
     );
+
+    let file_content = std::fs::read_to_string(&options_file)?;
+    assert_eq!(file_content, "{\"options\":{\"test\":42}}");
 
     Ok(())
 }


### PR DESCRIPTION
Not adding a new test because it's inconsistent and won't pass in CI.

Tested manually:
```Ruby
require 'json'
require 'test/unit'
require_relative '../lib/optify'
require_relative 'my_config'

provider = Optify::OptionsWatcherBuilder.new
                                        .add_directory('../../tests/test_suites/simple/configs')
                                        .build
last_modified = provider.last_modified

puts "last_modified: #{last_modified}"

while true
  # Wait for input
  puts 'Run `touch ../../tests/test_suites/simple/configs/feature_A.json` and then press Enter to continue...'
  STDIN.gets
  last_modified = provider.last_modified
  puts "last_modified: #{last_modified}"
end
```

Maybe will add a test later.