### PR TITLE
Support restricting loaded features by conditions

### DIFF
--- a/.github/workflows/JS_build_test_publish.yml
+++ b/.github/workflows/JS_build_test_publish.yml
@@ -30,6 +30,7 @@ on:
 
 jobs:
   build:
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     strategy:
       fail-fast: true
       matrix:
@@ -149,7 +150,7 @@ jobs:
           if-no-files-found: error
   build-freebsd:
     # Disabled for now because it gives too many installation errors such as when trying to install `yarn`.
-    if: ${{ false }}
+    if: ${{ false && (github.event.pull_request.draft == false || github.event_name != 'pull_request') }}
     runs-on: macos-13
     name: "[FreeBSD] Build"
     steps:
@@ -202,6 +203,7 @@ jobs:
           if-no-files-found: error
   test-macOS-windows-binding:
     name: "[${{ matrix.settings.target }}] Test"
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     needs:
       - build
     strategy:
@@ -249,6 +251,7 @@ jobs:
         working-directory: ./js/optify-config
   test-linux-x64-gnu-binding:
     name: "[Linux-x64-gnu] Test"
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     needs:
       - build
     strategy:
@@ -284,6 +287,7 @@ jobs:
         run: docker run --rm -v ${{ github.workspace }}/tests:/build/tests -v ${{ github.workspace }}/rust:/build/rust -v ${{ github.workspace }}/js:/build/js -w /build/js/optify-config node:${{ matrix.node }}-slim bash -c 'set -ex && npm install -g corepack && corepack enable && yarn test'
   test-linux-aarch64-gnu-binding:
     name: "[aarch64-unknown-linux-gnu] Test"
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     needs:
       - build
     strategy:
@@ -329,6 +333,7 @@ jobs:
             yarn test
   test-linux-aarch64-musl-binding:
     name: "[aarch64-unknown-linux-musl] Test"
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     needs:
       - build
     runs-on: ubuntu-latest
@@ -370,6 +375,7 @@ jobs:
             yarn test
   universal-macOS:
     name: Build universal macOS binary
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     needs:
       - build
     runs-on: macos-latest
@@ -412,6 +418,7 @@ jobs:
           if-no-files-found: error
   publish:
     name: Publish
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     needs:
       # FreeBSD is disabled for now because it gives too many installation errors such as when trying to install `yarn`.

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -29,15 +29,31 @@ env:
   RB_SYS_CROSS_COMPILE: true
 
 jobs:
+  setup:
+    # Drafts: Only run on Ubuntu.
+    # Non-drafts: Run on both Ubuntu and macOS.
+    name: "Setup Build Matrix"
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.setup.outputs.matrix }}
+    steps:
+      - id: setup
+        run: |
+          if [[ "${{ github.event.pull_request.draft }}" == "true" ]]; then
+            matrix='["ubuntu-latest"]'
+          else
+            matrix='["ubuntu-latest", "macos-latest"]'
+          fi
+          echo "matrix=$matrix" >> $GITHUB_OUTPUT
+
   test:
     name: "Build & Test"
+    needs: setup
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true
       matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
+        os: ${{ fromJson(needs.setup.outputs.matrix) }}
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -62,8 +62,13 @@ jobs:
       uses: actions/cache@v4
       with:
         path: |
+          ~/.cargo/bin
           ~/.cargo/registry
           ~/.cargo/git
+          ./rust/optify/target/release/deps
+          ./js/optify-config/target/release/deps
+          ./ruby/optify/target/release/deps
+          ./python/optify/target/release/deps
         key: ${{ matrix.os }}-cargo-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
         restore-keys: |
           ${{ matrix.os }}-cargo-

--- a/.github/workflows/python_publish.yml
+++ b/.github/workflows/python_publish.yml
@@ -28,6 +28,7 @@ permissions:
 jobs:
   linux:
     runs-on: ${{ matrix.platform.runner }}
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     strategy:
       fail-fast: true
       matrix:
@@ -57,6 +58,7 @@ jobs:
 
   windows:
     runs-on: ${{ matrix.platform.runner }}
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     strategy:
       matrix:
         platform:
@@ -83,6 +85,7 @@ jobs:
 
   macos:
     runs-on: ${{ matrix.platform.runner }}
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     strategy:
       matrix:
         platform:
@@ -107,6 +110,7 @@ jobs:
           path: python/optify/dist
   sdist:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v4
       - name: Build sdist
@@ -122,7 +126,7 @@ jobs:
           path: python/optify/dist
 
   release:
-    if: ${{ startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main' }}
+    if: ${{ (startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main') && (github.event.pull_request.draft == false || github.event_name != 'pull_request') }}
     name: "Publish Release"
     runs-on: ubuntu-latest
     needs: [linux, windows, macos, sdist]

--- a/.github/workflows/ruby_cross-build.yml
+++ b/.github/workflows/ruby_cross-build.yml
@@ -25,6 +25,7 @@ jobs:
   # Following example from https://github.com/oxidize-rb/actions/blob/main/cross-gem
   ci-data:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     outputs:
       result: ${{ steps.fetch.outputs.result }}
     steps:
@@ -40,6 +41,7 @@ jobs:
   cross-gem:
     name: "Build"
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     needs: ci-data
     strategy:
       fail-fast: true
@@ -112,6 +114,7 @@ jobs:
   # This allows future versions of Ruby to be used that aren't explicitly supported by this action.
   source-gem:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/vsc_extension-build_test.yml
+++ b/.github/workflows/vsc_extension-build_test.yml
@@ -16,19 +16,33 @@ on:
   workflow_dispatch:
 
 jobs:
+  setup:
+    # Drafts: Only run on Ubuntu.
+    # Non-drafts: Run on both Ubuntu and macOS.
+    name: "Setup Build Matrix"
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.setup.outputs.matrix }}
+    steps:
+      - id: setup
+        run: |
+          matrix='[{"os": "ubuntu-latest", "targets": "alpine-arm64 alpine-x64 linux-arm64 linux-armhf linux-x64", "test_command": "xvfb-run -a npm test"}'
+          
+          if [[ "${{ github.event.pull_request.draft }}" != "true" ]]; then
+            matrix+=', {"os": "macos-latest", "targets": "darwin-arm64 darwin-x64", "test_command": "npm test"}'
+          fi
+          
+          matrix+=']'
+          echo "matrix=$matrix" >> $GITHUB_OUTPUT
+
   test:
     name: "Build & Test"
+    needs: setup
     runs-on: ${{ matrix.settings.os }}
     strategy:
       fail-fast: true
       matrix:
-        settings:
-          - os: ubuntu-latest
-            targets: 'alpine-arm64 alpine-x64 linux-arm64 linux-armhf linux-x64'
-            test_command: xvfb-run -a npm test
-          - os: macos-latest
-            targets: 'darwin-arm64 darwin-x64'
-            test_command: npm test
+        settings: ${{ fromJson(needs.setup.outputs.matrix) }}
     steps:
     - uses: actions/checkout@v4
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,7 +12,7 @@
 		{
 			"fileMatch": [
 				"rust/optify/tests/**/*.json",
-				"tests/test_suites/**/configs/**/*.json"
+				"tests/{invalid_suites,test_suites}/**/configs/**/*.json"
 			],
 			"url": "./schemas/feature_file.json"
 		}
@@ -20,7 +20,10 @@
 	"yaml.schemas": {
 		"./schemas/feature_file.json": [
 			"rust/optify/tests/**/*.{yaml,yml}",
-			"tests/test_suites/**/configs/**/*.{yaml,yml}"
+			"tests/{invalid_suites,test_suites}/**/configs/**/*.{yaml,yml}"
 		]
-	}
+	},
+	"cSpell.words": [
+		"optifile"
+	]
 }

--- a/ruby/optify/rbi/optify.rbi
+++ b/ruby/optify/rbi/optify.rbi
@@ -82,13 +82,13 @@ module Optify
       # Build using just one directory.
       # @param directory The directory to build the provider from.
       # @return The instance.
-      sig { params(directory: String).returns(OptionsRegistry) }
+      sig { params(directory: String).returns(T.attached_class) }
       def build(directory); end
 
       # Build from multiple directories.
       # @param directories The directories to build the provider from.
       # @return The instance.
-      sig { params(directories: T::Array[String]).returns(OptionsRegistry) }
+      sig { params(directories: T::Array[String]).returns(T.attached_class) }
       def build_from_directories(directories); end
     end
 

--- a/ruby/optify/sig/optify.rbs
+++ b/ruby/optify/sig/optify.rbs
@@ -65,12 +65,12 @@ class Optify::OptionsRegistry
   # Build using just one directory.
   # @param directory The directory to build the provider from.
   # @return The instance.
-  def build: (String directory) -> OptionsRegistry
+  def build: (String directory) -> instance
 
   # Build from multiple directories.
   # @param directories The directories to build the provider from.
   # @return The instance.
-  def build_from_directories: (::Array[String] directories) -> OptionsRegistry
+  def build_from_directories: (::Array[String] directories) -> instance
 
   # @return All of the aliases.
   def aliases: () -> ::Array[String]

--- a/rust/.vscode/settings.json
+++ b/rust/.vscode/settings.json
@@ -11,6 +11,7 @@
 	},
 	"cSpell.words": [
 		"debouncer",
+		"optifile",
 		"serde",
 		"unicase",
 		"walkdir"

--- a/rust/optify/src/provider/provider_impl.rs
+++ b/rust/optify/src/provider/provider_impl.rs
@@ -23,6 +23,7 @@ pub struct GetOptionsPreferences {
     /// It also makes it simpler and maybe faster to get from other programming languages.
     pub overrides_json: Option<String>,
     pub skip_feature_name_conversion: bool,
+    pub constraints: Option<serde_json::Value>,
 }
 
 impl Clone for GetOptionsPreferences {
@@ -30,6 +31,7 @@ impl Clone for GetOptionsPreferences {
         Self {
             overrides_json: self.overrides_json.clone(),
             skip_feature_name_conversion: self.skip_feature_name_conversion,
+            constraints: self.constraints.clone(),
         }
     }
 }
@@ -45,6 +47,7 @@ impl GetOptionsPreferences {
         Self {
             overrides_json: None,
             skip_feature_name_conversion: false,
+            constraints: None,
         }
     }
 

--- a/rust/optify/src/schema/conditions.rs
+++ b/rust/optify/src/schema/conditions.rs
@@ -1,0 +1,32 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ConditionOperator {
+    Equals,
+    Regex,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Condition {
+    pub json_path: Option<String>,
+    pub operator: ConditionOperator,
+    // TODO Think of a name other than "value".
+    pub value: Option<serde_json::Value>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum ConditionGroup {
+    And { and: Vec<ConditionExpression> },
+    Or { or: Vec<ConditionExpression> },
+    Not { not: Box<ConditionExpression> },
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum ConditionExpression {
+    Group(ConditionGroup),
+    Condition(Condition),
+}

--- a/rust/optify/src/schema/conditions.rs
+++ b/rust/optify/src/schema/conditions.rs
@@ -4,16 +4,22 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "camelCase")]
 pub enum ConditionOperator {
     Equals,
-    Regex,
+    Matches,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum OperatorValue {
+    Equals { equals: serde_json::Value },
+    Matches { matches: String },
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Condition {
-    pub json_path: Option<String>,
-    pub operator: ConditionOperator,
-    // TODO Think of a name other than "value".
-    pub value: Option<serde_json::Value>,
+    pub json_path: String,
+    #[serde(flatten)]
+    pub operator_value: OperatorValue,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/rust/optify/src/schema/feature.rs
+++ b/rust/optify/src/schema/feature.rs
@@ -12,6 +12,9 @@ pub(crate) type ConfigurationOptions = config::Value;
 pub(crate) struct FeatureConfiguration {
     pub imports: Option<Vec<String>>,
     pub metadata: Option<OptionsMetadata>,
+    /// Conditions to automatically enable this feature file when constraints are given when getting configuration options.
+    ///
+    /// More details in the JSON schema.
     pub conditions: Option<ConditionExpression>,
     pub options: Option<ConfigurationOptions>,
 }

--- a/rust/optify/src/schema/feature.rs
+++ b/rust/optify/src/schema/feature.rs
@@ -2,6 +2,7 @@
 
 use serde::Deserialize;
 
+use super::conditions::ConditionExpression;
 use super::metadata::OptionsMetadata;
 
 pub(crate) type ConfigurationOptions = config::Value;
@@ -11,5 +12,6 @@ pub(crate) type ConfigurationOptions = config::Value;
 pub(crate) struct FeatureConfiguration {
     pub imports: Option<Vec<String>>,
     pub metadata: Option<OptionsMetadata>,
+    pub conditions: Option<ConditionExpression>,
     pub options: Option<ConfigurationOptions>,
 }

--- a/rust/optify/src/schema/mod.rs
+++ b/rust/optify/src/schema/mod.rs
@@ -1,2 +1,3 @@
+pub mod conditions;
 pub(crate) mod feature;
 pub mod metadata;

--- a/schemas/feature_file.json
+++ b/schemas/feature_file.json
@@ -28,6 +28,10 @@
 				}
 			}
 		},
+		"conditions": {
+			"$ref": "#/definitions/conditionExpression",
+			"description": "Conditions to automatically enable this feature file when constraints are given when getting configuration options. These are meant for temporary experimental features that should only be enabled in some requests.\n\nIf no constraints are given, then these conditions are ignored. Most projects should either always use constraints in every request or never use constraints in order to avoid confusion.\n\nConditions cannot be used in imported features. This helps keep retrieving and building configuration options fast and more predictable because imports do not need to be re-evaluated. Instead, keep each feature file as granular and self-contained as possible, then use conditions and import the required granular features in a feature file that defines a common scenario."
+		},
 		"imports": {
 			"type": "array",
 			"description": "List of canonical feature names to import or inherit from. Canonical feature names are derived from the relative path to the file, but without the file extension in order to keep canonical feature names clear.",
@@ -48,5 +52,96 @@
 			"type": "object"
 		}
 	},
-	"minProperties": 1
+	"minProperties": 1,
+	"definitions": {
+		"condition": {
+			"type": "object",
+			"properties": {
+				"jsonPath": {
+					"type": "string",
+					"description": "JSONPath expression to evaluate against the context"
+				},
+				"equals": {
+					"description": "Value to compare for equality"
+				},
+				"matches": {
+					"type": "string",
+					"description": "Regular expression pattern to match against"
+				}
+			},
+			"required": [
+				"jsonPath"
+			],
+			"oneOf": [
+				{
+					"required": [
+						"equals"
+					]
+				},
+				{
+					"required": [
+						"matches"
+					]
+				}
+			],
+			"additionalProperties": false
+		},
+		"conditionGroup": {
+			"type": "object",
+			"oneOf": [
+				{
+					"properties": {
+						"and": {
+							"type": "array",
+							"items": {
+								"$ref": "#/definitions/conditionExpression"
+							},
+							"minItems": 1
+						}
+					},
+					"required": [
+						"and"
+					],
+					"additionalProperties": false
+				},
+				{
+					"properties": {
+						"or": {
+							"type": "array",
+							"items": {
+								"$ref": "#/definitions/conditionExpression"
+							},
+							"minItems": 1
+						}
+					},
+					"required": [
+						"or"
+					],
+					"additionalProperties": false
+				},
+				{
+					"properties": {
+						"not": {
+							"$ref": "#/definitions/conditionExpression"
+						}
+					},
+					"required": [
+						"not"
+					],
+					"additionalProperties": false
+				}
+			]
+		},
+		"conditionExpression": {
+			"default": {},
+			"oneOf": [
+				{
+					"$ref": "#/definitions/condition"
+				},
+				{
+					"$ref": "#/definitions/conditionGroup"
+				}
+			]
+		}
+	}
 }

--- a/tests/invalid_suites/conditions_in_import/configs/invalid.yaml
+++ b/tests/invalid_suites/conditions_in_import/configs/invalid.yaml
@@ -1,0 +1,4 @@
+# This optifile is imported so it cannot contain conditions.
+conditions:
+  jsonPath: "$.key"
+  equals: "anything"

--- a/tests/invalid_suites/conditions_in_import/configs/parent.yaml
+++ b/tests/invalid_suites/conditions_in_import/configs/parent.yaml
@@ -1,0 +1,2 @@
+imports:
+  - invalid

--- a/tests/test_suites/conditions/configs/A.json
+++ b/tests/test_suites/conditions/configs/A.json
@@ -1,0 +1,22 @@
+{
+	"conditions": {
+		"and": [
+			{
+				"jsonPath": "$.info",
+				"operator": "equals",
+				"value": 3
+			},
+			{
+				"jsonPath": "$.status",
+				"operator": "regex",
+				"value": "^(active|new)$"
+			}
+		]
+	},
+	"options": {
+		"config": {
+			"key": "from A",
+			"key_a": "only in A"
+		}
+	}
+}

--- a/tests/test_suites/conditions/configs/A.json
+++ b/tests/test_suites/conditions/configs/A.json
@@ -3,13 +3,11 @@
 		"and": [
 			{
 				"jsonPath": "$.info",
-				"operator": "equals",
-				"value": 3
+				"equals": 3
 			},
 			{
 				"jsonPath": "$.status",
-				"operator": "regex",
-				"value": "^(active|new)$"
+				"matches": "^(active|new)$"
 			}
 		]
 	},

--- a/tests/test_suites/conditions/configs/B.yaml
+++ b/tests/test_suites/conditions/configs/B.yaml
@@ -1,0 +1,4 @@
+options:
+    config:
+        key: "from B"
+        key_b: "only in B"

--- a/tests/test_suites/conditions/configs/README.md
+++ b/tests/test_suites/conditions/configs/README.md
@@ -1,0 +1,2 @@
+The configuration files for tests that use conditions.
+This file is ignored by the builder.

--- a/tests/test_suites/conditions/expectations/A_B_with_info_2.json
+++ b/tests/test_suites/conditions/expectations/A_B_with_info_2.json
@@ -1,0 +1,15 @@
+{
+	"features": [
+		"A",
+		"B"
+	],
+	"constraints": {
+		"info": 2
+	},
+	"options": {
+		"config": {
+			"key": "from B",
+			"key_b": "only in B"
+		}
+	}
+}

--- a/tests/test_suites/conditions/expectations/A_B_with_info_3.json
+++ b/tests/test_suites/conditions/expectations/A_B_with_info_3.json
@@ -1,0 +1,16 @@
+{
+	"features": [
+		"A",
+		"B"
+	],
+	"constraints": {
+		"info": 3
+	},
+	"options": {
+		"config": {
+			"key": "from B",
+			"key_a": "from A",
+			"key_b": "only in B"
+		}
+	}
+}

--- a/tests/test_suites/conditions/expectations/a_b.json
+++ b/tests/test_suites/conditions/expectations/a_b.json
@@ -1,0 +1,13 @@
+{
+	"features": [
+		"a",
+		"b"
+	],
+	"options": {
+		"config": {
+			"key": "from B",
+			"key_a": "from A",
+			"key_b": "only in B"
+		}
+	}
+}

--- a/tests/test_suites/conditions/expectations/just_A.json
+++ b/tests/test_suites/conditions/expectations/just_A.json
@@ -1,0 +1,11 @@
+{
+	"features": [
+		"A"
+	],
+	"options": {
+		"config": {
+			"key": "from A",
+			"key_a": "only in A"
+		}
+	}
+}

--- a/tests/test_suites/conditions/expectations/just_B.json
+++ b/tests/test_suites/conditions/expectations/just_B.json
@@ -1,0 +1,11 @@
+{
+	"features": [
+		"b"
+	],
+	"options": {
+		"config": {
+			"key": "from B",
+			"key_b": "only in B"
+		}
+	}
+}

--- a/tests/test_suites/simple/configs/README.md
+++ b/tests/test_suites/simple/configs/README.md
@@ -1,2 +1,2 @@
-The configuration files for our code.
-This file is ignored.
+The configuration files for some simple tests.
+This file is ignored by the builder.


### PR DESCRIPTION
Still thinking about the exact schema and a way to clarify that the conditions only apply to directly requested features and not imports.

Concerns:
* Clarity vs. efficiency: How to make it clear that conditions only apply when a feature is used directly and not when imported? Imports are resolved at build time for efficiency and not when a config is requested. I'd like to keep that. Can use a more clear property, like `conditions_to_use_feature_but_not_import` haha that's way too long, `direct_conditions`? I like that all of the names are just 1 word right now and we don't need to worry about snake_case vs. camelCase. We should ban conditions in imported files.
* Keep the language simple, but powerful.

Ruby: Improve sig for class build* methods to return a more specific type.