### PR TITLE
[Ruby] Bump to 1.17.8

### DIFF
--- a/ruby/optify/benchmarks/run.sh
+++ b/ruby/optify/benchmarks/run.sh
@@ -6,7 +6,7 @@ cd "$(dirname "$0")/.."
 
 rm -rf target/ tmp/ pkg/ ext/optify_ruby/target/
 
-RB_SYS_CARGO_PROFILE='release' RB_SYS_CROSS_COMPILE=true rake native gem
+RB_SYS_CARGO_PROFILE='release' rake native gem
 
 echo "Running benchmarks..."
 for benchmark_file in benchmarks/*.rb; do

--- a/ruby/optify/optify.gemspec
+++ b/ruby/optify/optify.gemspec
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-VERSION = '1.17.7'
+VERSION = '1.17.8'
 
 Gem::Specification.new do |spec|
   spec.name = 'optify-config'
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   # needed until rubygems Rust support is out of beta
   spec.add_dependency 'rb_sys', '~> 0.9.117'
 
-  spec.add_dependency 'optify-from_hash'
+  spec.add_dependency 'optify-from_hash', '~> 0.2.0'
 
   sorbet_version = '>= 0.5'
   sorbet_version_upper_bound = '< 1'


### PR DESCRIPTION
Main changes since non-yanked release 1.17.4: https://github.com/juharris/optify/compare/173e19a6d4ec06a29fa2bd8ab4caf5115a2ebfc4...502e0fa58d1ed7c7661f31f4051e33d9a7b45393

* Use optify-from_hash gem
* optimize getting objects by building Ruby hashes in Rust