### PR TITLE
[Ruby] Use _get_options to avoid extra method call

### DIFF
--- a/ruby/optify/lib/optify_ruby/provider_module.rb
+++ b/ruby/optify/lib/optify_ruby/provider_module.rb
@@ -111,7 +111,7 @@ module Optify
         preferences.skip_feature_name_conversion = true
         preferences.enable_configurable_strings if are_configurable_strings_enabled
 
-        result = get_options(key, feature_names, config_class, nil, preferences)
+        result = _get_options(key, feature_names, config_class, nil, preferences)
 
         @cache #: as !nil
           .[]= cache_key, result

--- a/ruby/optify/optify.gemspec
+++ b/ruby/optify/optify.gemspec
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-VERSION = '1.17.8'
+VERSION = '1.17.9'
 
 Gem::Specification.new do |spec|
   spec.name = 'optify-config'


### PR DESCRIPTION
Bump to 1.17.9.