### PR TITLE
[Ruby] Correct source gem build by using workspace patch for local optify crate

### DIFF
--- a/ruby/optify/Cargo.toml
+++ b/ruby/optify/Cargo.toml
@@ -2,3 +2,8 @@
 [workspace]
 members = ["ext/optify_ruby"]
 resolver = "2"
+
+# Use the local optify crate for development and CI.
+# When building from the source gem (no workspace), Cargo fetches from crates.io instead.
+[patch.crates-io]
+optify = { path = "../../rust/optify" }

--- a/ruby/optify/ext/optify_ruby/Cargo.toml
+++ b/ruby/optify/ext/optify_ruby/Cargo.toml
@@ -21,6 +21,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 magnus = "0.8.2"
-optify = { path = "../../../../rust/optify", version = "0.20.5" }
+optify = "0.20.5"
 rb-sys = { version = "0.9.124", default-features = false, features = ["ruby-static"] }
 serde_json = "1.0.143"

--- a/ruby/optify/optify.gemspec
+++ b/ruby/optify/optify.gemspec
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-VERSION = '1.20.1'
+VERSION = '1.20.2'
 
 Gem::Specification.new do |spec|
   spec.name = 'optify-config'


### PR DESCRIPTION
Claude says:
The path dependency `path = "../../../../rust/optify"` doesn't exist when someone installs the source gem because only `ext/` is packaged. Move the local path override to a `[patch.crates-io]` section in the workspace Cargo.toml so that local dev and CI use the local Rust source while source gem installs fetch optify from crates.io.