### PR TITLE
[Ruby] Bump version to 1.21.1

### DIFF
--- a/ruby/optify/optify.gemspec
+++ b/ruby/optify/optify.gemspec
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-VERSION = '1.21.0'
+VERSION = '1.21.1'
 
 Gem::Specification.new do |spec|
   spec.name = 'optify-config'
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   # needed until rubygems Rust support is out of beta
   spec.add_dependency 'rb_sys', '~> 0.9.124'
 
-  spec.add_dependency 'optify-from_hash', '~> 0.2.1'
+  spec.add_dependency 'optify-from_hash', '~> 0.2.2'
   spec.add_dependency 'sin_lru_redux', '~> 2.5.2'
 
   sorbet_version = '>= 0.5'


### PR DESCRIPTION
## Summary

Bump the Ruby gem version from 1.21.0 to 1.21.1 and update the `optify-from_hash` dependency from `~> 0.2.1` to `~> 0.2.2`.

🤖 Generated with the help of Claude Code. This pull request description and possibly the code was generated by AI, but the user has most likely reviewed all of the code changes.