### PR TITLE
[JS] Add setConstraints and setOverrides preference methods

### DIFF
--- a/js/optify-config/package.json
+++ b/js/optify-config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@optify/config",
-	"version": "1.3.0",
+	"version": "1.4.0",
 	"description": "Simplifies **configuration driven development**: getting the right configuration options for a process or request using pre-loaded configurations from files (JSON, YAML, etc.) to manage options for feature flags, experiments, or flights.",
 	"keywords": [
 		"configuration"

--- a/js/optify-config/src/preferences.rs
+++ b/js/optify-config/src/preferences.rs
@@ -34,8 +34,18 @@ impl JsGetOptionsPreferences {
   }
 
   #[napi]
+  pub fn set_constraints(&mut self, constraints: Option<serde_json::Value>) {
+    self.inner.set_constraints(constraints);
+  }
+
+  #[napi]
   pub fn set_constraints_json(&mut self, constraints_json: Option<String>) {
     self.inner.set_constraints_json(constraints_json.as_deref());
+  }
+
+  #[napi]
+  pub fn set_overrides(&mut self, overrides: Option<serde_json::Value>) {
+    self.inner.overrides = overrides;
   }
 
   #[napi]

--- a/js/optify-config/tests/optify.test.ts
+++ b/js/optify-config/tests/optify.test.ts
@@ -23,7 +23,7 @@ const runSuite = (suitePath: string) => {
 		const preferences = new GetOptionsPreferences();
 		preferences.enableConfigurableStrings();
 		if (constraints) {
-			preferences.setConstraintsJson(JSON.stringify(constraints));
+			preferences.setConstraints(constraints);
 		}
 		for (const { name, provider } of providers) {
 			test(`${name} ${testCase}`, () => {

--- a/js/optify-config/tests/provider.test.ts
+++ b/js/optify-config/tests/provider.test.ts
@@ -126,21 +126,21 @@ describe("mapFeatureNames", () => {
 
 		test(`${name} constraints matching all features`, () => {
 			const preferences = new GetOptionsPreferences();
-			preferences.setConstraintsJson(JSON.stringify({ info: 3, status: "new" }));
+			preferences.setConstraints({ info: 3, status: "new" });
 			const result = provider.mapFeatureNames(["a", "b"], preferences);
 			expect(result).toEqual(["A", "B"]);
 		});
 
 		test(`${name} constraints filtering out a feature`, () => {
 			const preferences = new GetOptionsPreferences();
-			preferences.setConstraintsJson(JSON.stringify({ info: 2, status: "new" }));
+			preferences.setConstraints({ info: 2, status: "new" });
 			const result = provider.mapFeatureNames(["a", "b"], preferences);
 			expect(result).toEqual([null, "B"]);
 		});
 
 		test(`${name} reversed input order with filtering`, () => {
 			const preferences = new GetOptionsPreferences();
-			preferences.setConstraintsJson(JSON.stringify({ info: 2, status: "new" }));
+			preferences.setConstraints({ info: 2, status: "new" });
 			const result = provider.mapFeatureNames(["b", "a"], preferences);
 			expect(result).toEqual(["B", null]);
 		});
@@ -152,4 +152,46 @@ describe("mapFeatureNames", () => {
 			expect(result).toEqual([]);
 		});
 	}
+});
+
+describe("overrides", () => {
+	const provider = OptionsProvider.buildFromDirectories([configsPath]);
+
+	test("hasOverrides is false by default", () => {
+		const preferences = new GetOptionsPreferences();
+		expect(preferences.hasOverrides()).toBe(false);
+	});
+
+	test("setOverrides sets overrides and hasOverrides returns true", () => {
+		const preferences = new GetOptionsPreferences();
+		preferences.setOverrides({ myConfig: { rootString2: "overridden value" } });
+		expect(preferences.hasOverrides()).toBe(true);
+
+		const options = provider.getAllOptions(["feature_A"], preferences);
+		expect(options.myConfig.rootString2).toBe("overridden value");
+
+		preferences.setOverrides(null);
+		expect(preferences.hasOverrides()).toBe(false);
+	});
+
+	test("setOverridesJson sets overrides from a JSON string", () => {
+		const preferences = new GetOptionsPreferences();
+		preferences.setOverridesJson(JSON.stringify({ myConfig: { rootString2: "json override" } }));
+		expect(preferences.hasOverrides()).toBe(true);
+
+		const options = provider.getAllOptions(["feature_A"], preferences);
+		expect(options.myConfig.rootString2).toBe("json override");
+
+		preferences.setOverridesJson(null);
+		expect(preferences.hasOverrides()).toBe(false);
+	});
+
+	test("overrides do not affect keys that are not overridden", () => {
+		const preferences = new GetOptionsPreferences();
+		preferences.setOverrides({ myConfig: { rootString2: "overridden" } });
+
+		const options = provider.getAllOptions(["feature_A"], preferences);
+		expect(options.myConfig.rootString).toBe("root string same");
+		expect(options.myConfig.rootString2).toBe("overridden");
+	});
 });


### PR DESCRIPTION
## Summary

- Add `setConstraints` and `setOverrides` methods to `GetOptionsPreferences` that accept native JS objects, complementing the existing JSON string variants
- Add tests for `setOverrides`, `setOverridesJson`, and `hasOverrides`
- Update existing tests to use `setConstraints` instead of `setConstraintsJson` where applicable
- Bump version to 1.4.0