### PR TITLE
[VS Extension] Include lru-cache in packaged extension

### DIFF
--- a/vscode/extension/.vscodeignore
+++ b/vscode/extension/.vscodeignore
@@ -26,8 +26,11 @@ out/tests/
 # Assets not needed in package
 assets/demo.gif
 
-# Exclude all node_modules except @optify/config (native addon dependency)
+# Exclude all node_modules except @optify/config (native addon) and its dependencies
 node_modules/**
 !node_modules/@optify/
 !node_modules/@optify/config/
 !node_modules/@optify/config/**
+# @optify/config dependencies — update if @optify/config adds new runtime deps
+!node_modules/lru-cache/
+!node_modules/lru-cache/**

--- a/vscode/extension/package-lock.json
+++ b/vscode/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "optify",
-	"version": "1.8.0",
+	"version": "1.8.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "optify",
-			"version": "1.8.0",
+			"version": "1.8.1",
 			"license": "MIT",
 			"dependencies": {
 				"@optify/config": "^1.5.0",

--- a/vscode/extension/package.json
+++ b/vscode/extension/package.json
@@ -2,7 +2,7 @@
 	"name": "optify",
 	"displayName": "Optify",
 	"description": "Helps manage Optify feature files.",
-	"version": "1.8.0",
+	"version": "1.8.1",
 	"publisher": "optify-config",
 	"license": "MIT",
 	"repository": "https://github.com/juharris/optify",


### PR DESCRIPTION
## Summary
The published extension fails to activate with:
```
Cannot find module 'lru-cache'
```

`@optify/config` is marked as `external` in esbuild, so it and its dependencies are loaded from `node_modules` at runtime rather than being bundled. The `.vscodeignore` was correctly including `@optify/config` itself, but not its transitive dependency `lru-cache`. In development (F5 debug), the full `node_modules` tree is available so everything resolves. In the published `.vsix`, `lru-cache` was excluded by the `node_modules/**` rule.

## Changes
- Added `lru-cache` to the `.vscodeignore` un-exclude list
- Added a comment noting these lines must be updated if `@optify/config` gains new runtime dependencies

## Test Plan
- [x] Verified `lru-cache` is absent from the `.vsix` before the change
- [x] Verified `lru-cache` is present in the `.vsix` after the change