### PR TITLE
[JS][optify-config] Fix featuresWithMetadata returning undefined after cache reset

### DIFF
--- a/js/optify-config/package.json
+++ b/js/optify-config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@optify/config",
-	"version": "1.5.0",
+	"version": "1.5.1",
 	"description": "Simplifies **configuration driven development**: getting the right configuration options for a process or request using pre-loaded configurations from files (JSON, YAML, etc.) to manage options for feature flags, experiments, or flights.",
 	"keywords": [
 		"configuration"

--- a/js/optify-config/src/caching.ts
+++ b/js/optify-config/src/caching.ts
@@ -25,6 +25,7 @@ export interface CacheableInstance {
 	lastModified?(): number;
 	[CACHE_CREATION_TIME_KEY]?: number;
 	[FEATURES_WITH_METADATA_CACHE_KEY]?: Record<string, nativeBinding.OptionsMetadata>;
+	[FEATURES_WITH_METADATA_CACHE_TIME_KEY]?: number;
 	[OPTIONS_CACHE_KEY]?: OptionsCache;
 	[CACHE_INIT_OPTIONS_KEY]?: CacheInitOptions | null;
 	[SCHEMA_ID_COUNTER_KEY]?: number;
@@ -95,6 +96,7 @@ export function resetWatcherCachesIfModified(instance: CacheableInstance): void 
  */
 export function resetCaches(instance: CacheableInstance): void {
 	instance[FEATURES_WITH_METADATA_CACHE_KEY] = undefined;
+	instance[FEATURES_WITH_METADATA_CACHE_TIME_KEY] = undefined;
 	instance[OPTIONS_CACHE_KEY] = createOptionsCache(instance[CACHE_INIT_OPTIONS_KEY]);
 }
 

--- a/js/optify-config/src/index.ts
+++ b/js/optify-config/src/index.ts
@@ -135,10 +135,17 @@ export const OptionsWatcher = nativeBinding.OptionsWatcher;
 	const cachedTime = this[FEATURES_WITH_METADATA_CACHE_TIME_KEY];
 	const lastModifiedTime = this.lastModified();
 	if (cachedTime && lastModifiedTime <= cachedTime) {
-		return this[FEATURES_WITH_METADATA_CACHE_KEY];
+		const cachedResult = this[FEATURES_WITH_METADATA_CACHE_KEY];
+		if (cachedResult) {
+			return cachedResult;
+		}
 	}
 
-	resetCaches(this);
+	// Only reset the options cache if we previously had cached metadata and files have changed.
+	// On the first call (cachedTime is undefined) there is nothing stale to evict.
+	if (cachedTime) {
+		resetCaches(this);
+	}
 	this[FEATURES_WITH_METADATA_CACHE_TIME_KEY] = lastModifiedTime;
 	return (this[FEATURES_WITH_METADATA_CACHE_KEY] = this._featuresWithMetadata());
 };

--- a/js/optify-config/tests/watcher.test.ts
+++ b/js/optify-config/tests/watcher.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test, beforeEach, afterEach } from "@jest/globals";
 import fs from "fs";
 import os from "os";
 import path from "path";
-import { OptionsWatcher, WatcherOptions } from "../dist/index";
+import { CacheOptions, OptionsWatcher, WatcherOptions } from "../dist/index";
 
 const MODIFICATION_DEBOUNCE_MS = 10;
 const RETRY_DELAY = MODIFICATION_DEBOUNCE_MS * 2 + 100;
@@ -18,6 +18,66 @@ describe("OptionsWatcher", () => {
 	afterEach(() => {
 		fs.rmSync(tempDir, { recursive: true, force: true });
 	});
+
+	test(
+		"featuresWithMetadata is not undefined after getAllOptions invalidates the cache",
+		(done) => {
+			const configPath = path.join(tempDir, "config.yaml");
+			fs.writeFileSync(configPath, "");
+
+			const options = new WatcherOptions();
+			options.setDebounceDurationMs(MODIFICATION_DEBOUNCE_MS);
+			let watcher: OptionsWatcher | null = OptionsWatcher.buildWithOptions(tempDir, options);
+
+			let listenerCalled = false;
+
+			watcher.addListener(() => {
+				if (listenerCalled) return;
+				listenerCalled = true;
+
+				// Populate the featuresWithMetadata cache after the modification is detected.
+				// This sets FEATURES_WITH_METADATA_CACHE_TIME_KEY to the new lastModified() time,
+				// but leaves CACHE_CREATION_TIME_KEY as undefined since init() was not called.
+				const afterChange = watcher!.featuresWithMetadata();
+				expect(afterChange).toBeDefined();
+
+				// getAllOptions with cacheOptions triggers resetWatcherCachesIfModified which, because
+				// CACHE_CREATION_TIME_KEY is undefined, calls resetCaches and clears
+				// FEATURES_WITH_METADATA_CACHE_KEY without clearing FEATURES_WITH_METADATA_CACHE_TIME_KEY.
+				watcher!.getAllOptions([], null, new CacheOptions());
+
+				// Before the fix: featuresWithMetadata returns undefined because the time key still
+				// matches lastModified() but the cache was cleared without resetting the time key.
+				const afterInvalidation = watcher!.featuresWithMetadata();
+				expect(afterInvalidation).toBeDefined();
+
+				watcher = null;
+				done();
+			});
+
+			setTimeout(() => {
+				let attempts = 0;
+				const tryModification = () => {
+					if (listenerCalled) {
+						return;
+					}
+					if (attempts >= MAX_RETRY_ATTEMPTS) {
+						done(new Error("Listener was not called after maximum retry attempts"));
+						return;
+					}
+
+					++attempts;
+					const newContent = `options:\n  key: value-${Date.now()}`;
+					fs.writeFileSync(configPath, newContent);
+
+					setTimeout(tryModification, RETRY_DELAY + attempts * 500);
+				};
+
+				tryModification();
+			}, MODIFICATION_DEBOUNCE_MS + 100);
+		},
+		MODIFICATION_DEBOUNCE_MS + 100 + RETRY_DELAY * MAX_RETRY_ATTEMPTS + MAX_RETRY_ATTEMPTS ** 2 * 500,
+	);
 
 	test(
 		"listener is called when a file is modified and cache is invalidated",
@@ -153,4 +213,21 @@ describe("OptionsWatcher", () => {
 		},
 		MODIFICATION_DEBOUNCE_MS + 100 + RETRY_DELAY * MAX_RETRY_ATTEMPTS + MAX_RETRY_ATTEMPTS ** 2 * 200,
 	);
+
+	test("featuresWithMetadata on first call does not evict the options cache", () => {
+		const configPath = path.join(tempDir, "config.yaml");
+		fs.writeFileSync(configPath, "options:\n  key: value");
+
+		const watcher = OptionsWatcher.build(tempDir);
+
+		// Prime the options cache before ever calling featuresWithMetadata.
+		const firstResult = watcher.getAllOptions([], null, new CacheOptions());
+
+		// First call to featuresWithMetadata should not reset the options cache.
+		watcher.featuresWithMetadata();
+
+		// The options cache should still be intact — same reference returned.
+		const secondResult = watcher.getAllOptions([], null, new CacheOptions());
+		expect(secondResult).toBe(firstResult);
+	});
 });


### PR DESCRIPTION
resetCaches cleared FEATURES_WITH_METADATA_CACHE_KEY but left FEATURES_WITH_METADATA_CACHE_TIME_KEY intact. On the next call to featuresWithMetadata(), the stale time matched lastModified(), so the method treated the cleared (undefined) cache value as valid and returned it directly.

Fix by also clearing FEATURES_WITH_METADATA_CACHE_TIME_KEY in resetCaches, and add FEATURES_WITH_METADATA_CACHE_TIME_KEY to the CacheableInstance interface so the property is properly typed.

Adds a regression test that reproduces the exact scenario: calling featuresWithMetadata() after a file modification (which sets the time key), then triggering getAllOptions() with cacheOptions (which calls resetWatcherCachesIfModified → resetCaches), and asserting that a subsequent featuresWithMetadata() call is not undefined.
