### PR TITLE
[Elixir] Schedule rayon-using NIFs on dirty CPU schedulers

### DIFF
--- a/elixir/optify/lib/optify/get_options_preferences.ex
+++ b/elixir/optify/lib/optify/get_options_preferences.ex
@@ -26,12 +26,13 @@ defmodule Optify.GetOptionsPreferences do
     prefs
   end
 
-  def set_constraints(%__MODULE__{ref: ref} = prefs, constraints) do
+  def set_constraints(%__MODULE__{ref: ref} = prefs, constraints) when is_map(constraints) do
     Optify.Native.preferences_set_constraints(ref, constraints)
     prefs
   end
 
-  def set_constraints_json(%__MODULE__{ref: ref} = prefs, constraints_json) do
+  def set_constraints_json(%__MODULE__{ref: ref} = prefs, constraints_json)
+      when is_binary(constraints_json) do
     Optify.Native.preferences_set_constraints_json(ref, constraints_json)
     prefs
   end
@@ -44,12 +45,12 @@ defmodule Optify.GetOptionsPreferences do
     Optify.Native.preferences_get_constraints_json(ref)
   end
 
-  def set_overrides_json(%__MODULE__{ref: ref} = prefs, json) do
+  def set_overrides_json(%__MODULE__{ref: ref} = prefs, json) when is_binary(json) do
     Optify.Native.preferences_set_overrides_json(ref, json)
     prefs
   end
 
-  def set_overrides(%__MODULE__{ref: ref} = prefs, overrides) do
+  def set_overrides(%__MODULE__{ref: ref} = prefs, overrides) when is_map(overrides) do
     Optify.Native.preferences_set_overrides(ref, overrides)
     prefs
   end
@@ -58,7 +59,8 @@ defmodule Optify.GetOptionsPreferences do
     Optify.Native.preferences_get_overrides_json(ref)
   end
 
-  def set_skip_feature_name_conversion(%__MODULE__{ref: ref} = prefs, value) do
+  def set_skip_feature_name_conversion(%__MODULE__{ref: ref} = prefs, value)
+      when is_boolean(value) do
     Optify.Native.preferences_set_skip_feature_name_conversion(ref, value)
     prefs
   end

--- a/elixir/optify/lib/optify/options_provider.ex
+++ b/elixir/optify/lib/optify/options_provider.ex
@@ -8,7 +8,7 @@ defmodule Optify.OptionsProvider do
 
   defstruct [:ref]
 
-  def build(directory) do
+  def build(directory) when is_binary(directory) do
     case Optify.Native.provider_build(directory) do
       {:ok, ref} -> {:ok, %__MODULE__{ref: ref}}
       {:error, _} = err -> err
@@ -23,7 +23,8 @@ defmodule Optify.OptionsProvider do
     end
   end
 
-  def build_with_schema(directory, schema_path) do
+  def build_with_schema(directory, schema_path)
+      when is_binary(directory) and is_binary(schema_path) do
     case Optify.Native.provider_build_with_schema(directory, schema_path) do
       {:ok, ref} -> {:ok, %__MODULE__{ref: ref}}
       {:error, _} = err -> err
@@ -38,7 +39,7 @@ defmodule Optify.OptionsProvider do
     end
   end
 
-  def build_from_directories(directories) do
+  def build_from_directories(directories) when is_list(directories) do
     case Optify.Native.provider_build_from_directories(directories) do
       {:ok, ref} -> {:ok, %__MODULE__{ref: ref}}
       {:error, _} = err -> err
@@ -53,7 +54,8 @@ defmodule Optify.OptionsProvider do
     end
   end
 
-  def build_from_directories_with_schema(directories, schema_path) do
+  def build_from_directories_with_schema(directories, schema_path)
+      when is_list(directories) and is_binary(schema_path) do
     case Optify.Native.provider_build_from_directories_with_schema(directories, schema_path) do
       {:ok, ref} -> {:ok, %__MODULE__{ref: ref}}
       {:error, _} = err -> err
@@ -80,11 +82,13 @@ defmodule Optify.OptionsProvider do
     Optify.Native.provider_get_features_and_aliases(ref)
   end
 
-  def get_canonical_feature_name(%__MODULE__{ref: ref}, feature_name) do
+  def get_canonical_feature_name(%__MODULE__{ref: ref}, feature_name)
+      when is_binary(feature_name) do
     Optify.Native.provider_get_canonical_feature_name(ref, feature_name)
   end
 
-  def get_canonical_feature_name!(%__MODULE__{ref: ref}, feature_name) do
+  def get_canonical_feature_name!(%__MODULE__{ref: ref}, feature_name)
+      when is_binary(feature_name) do
     case Optify.Native.provider_get_canonical_feature_name(ref, feature_name) do
       {:ok, name} -> name
       {:error, reason} -> raise ArgumentError, reason
@@ -92,13 +96,15 @@ defmodule Optify.OptionsProvider do
     end
   end
 
-  def get_canonical_feature_names(%__MODULE__{ref: ref}, feature_names) do
+  def get_canonical_feature_names(%__MODULE__{ref: ref}, feature_names)
+      when is_list(feature_names) do
     Optify.Native.provider_get_canonical_feature_names(ref, feature_names)
   end
 
   def get_all_options(%__MODULE__{ref: ref}, feature_names, %Optify.GetOptionsPreferences{
         ref: prefs_ref
-      }) do
+      })
+      when is_list(feature_names) do
     Optify.Native.provider_get_all_options(ref, feature_names, prefs_ref)
   end
 
@@ -109,7 +115,8 @@ defmodule Optify.OptionsProvider do
 
   def get_options(%__MODULE__{ref: ref}, key, feature_names, %Optify.GetOptionsPreferences{
         ref: prefs_ref
-      }) do
+      })
+      when is_binary(key) and is_list(feature_names) do
     Optify.Native.provider_get_options(ref, key, feature_names, prefs_ref)
   end
 
@@ -122,7 +129,8 @@ defmodule Optify.OptionsProvider do
         %__MODULE__{ref: ref},
         feature_names,
         %Optify.GetOptionsPreferences{ref: prefs_ref}
-      ) do
+      )
+      when is_list(feature_names) do
     Optify.Native.provider_get_filtered_feature_names(ref, feature_names, prefs_ref)
   end
 
@@ -133,7 +141,8 @@ defmodule Optify.OptionsProvider do
 
   def map_feature_names(%__MODULE__{ref: ref}, feature_names, %Optify.GetOptionsPreferences{
         ref: prefs_ref
-      }) do
+      })
+      when is_list(feature_names) do
     Optify.Native.provider_map_feature_names(ref, feature_names, prefs_ref)
   end
 
@@ -142,7 +151,8 @@ defmodule Optify.OptionsProvider do
     map_feature_names(provider, feature_names, prefs)
   end
 
-  def has_conditions?(%__MODULE__{ref: ref}, canonical_feature_name) do
+  def has_conditions?(%__MODULE__{ref: ref}, canonical_feature_name)
+      when is_binary(canonical_feature_name) do
     Optify.Native.provider_has_conditions(ref, canonical_feature_name)
   end
 end

--- a/elixir/optify/lib/optify/options_provider_builder.ex
+++ b/elixir/optify/lib/optify/options_provider_builder.ex
@@ -9,7 +9,7 @@ defmodule Optify.OptionsProviderBuilder do
     %__MODULE__{ref: Optify.Native.provider_builder_new()}
   end
 
-  def add_directory(%__MODULE__{ref: ref} = builder, directory) do
+  def add_directory(%__MODULE__{ref: ref} = builder, directory) when is_binary(directory) do
     case Optify.Native.provider_builder_add_directory(ref, directory) do
       {:ok, _} -> {:ok, builder}
       {:error, _} = err -> err

--- a/elixir/optify/lib/optify/options_watcher.ex
+++ b/elixir/optify/lib/optify/options_watcher.ex
@@ -6,7 +6,7 @@ defmodule Optify.OptionsWatcher do
 
   defstruct [:ref]
 
-  def build(directory) do
+  def build(directory) when is_binary(directory) do
     case Optify.Native.watcher_build(directory) do
       {:ok, ref} -> {:ok, %__MODULE__{ref: ref}}
       {:error, _} = err -> err
@@ -21,7 +21,8 @@ defmodule Optify.OptionsWatcher do
     end
   end
 
-  def build_with_schema(directory, schema_path) do
+  def build_with_schema(directory, schema_path)
+      when is_binary(directory) and is_binary(schema_path) do
     case Optify.Native.watcher_build_with_schema(directory, schema_path) do
       {:ok, ref} -> {:ok, %__MODULE__{ref: ref}}
       {:error, _} = err -> err
@@ -36,7 +37,7 @@ defmodule Optify.OptionsWatcher do
     end
   end
 
-  def build_from_directories(directories) do
+  def build_from_directories(directories) when is_list(directories) do
     case Optify.Native.watcher_build_from_directories(directories) do
       {:ok, ref} -> {:ok, %__MODULE__{ref: ref}}
       {:error, _} = err -> err
@@ -51,7 +52,8 @@ defmodule Optify.OptionsWatcher do
     end
   end
 
-  def build_from_directories_with_schema(directories, schema_path) do
+  def build_from_directories_with_schema(directories, schema_path)
+      when is_list(directories) and is_binary(schema_path) do
     case Optify.Native.watcher_build_from_directories_with_schema(directories, schema_path) do
       {:ok, ref} -> {:ok, %__MODULE__{ref: ref}}
       {:error, _} = err -> err
@@ -78,11 +80,13 @@ defmodule Optify.OptionsWatcher do
     Optify.Native.watcher_get_features_and_aliases(ref)
   end
 
-  def get_canonical_feature_name(%__MODULE__{ref: ref}, feature_name) do
+  def get_canonical_feature_name(%__MODULE__{ref: ref}, feature_name)
+      when is_binary(feature_name) do
     Optify.Native.watcher_get_canonical_feature_name(ref, feature_name)
   end
 
-  def get_canonical_feature_name!(%__MODULE__{ref: ref}, feature_name) do
+  def get_canonical_feature_name!(%__MODULE__{ref: ref}, feature_name)
+      when is_binary(feature_name) do
     case Optify.Native.watcher_get_canonical_feature_name(ref, feature_name) do
       {:ok, name} -> name
       {:error, reason} -> raise ArgumentError, reason
@@ -90,13 +94,15 @@ defmodule Optify.OptionsWatcher do
     end
   end
 
-  def get_canonical_feature_names(%__MODULE__{ref: ref}, feature_names) do
+  def get_canonical_feature_names(%__MODULE__{ref: ref}, feature_names)
+      when is_list(feature_names) do
     Optify.Native.watcher_get_canonical_feature_names(ref, feature_names)
   end
 
   def get_all_options(%__MODULE__{ref: ref}, feature_names, %Optify.GetOptionsPreferences{
         ref: prefs_ref
-      }) do
+      })
+      when is_list(feature_names) do
     Optify.Native.watcher_get_all_options(ref, feature_names, prefs_ref)
   end
 
@@ -107,7 +113,8 @@ defmodule Optify.OptionsWatcher do
 
   def get_options(%__MODULE__{ref: ref}, key, feature_names, %Optify.GetOptionsPreferences{
         ref: prefs_ref
-      }) do
+      })
+      when is_binary(key) and is_list(feature_names) do
     Optify.Native.watcher_get_options(ref, key, feature_names, prefs_ref)
   end
 
@@ -120,7 +127,8 @@ defmodule Optify.OptionsWatcher do
         %__MODULE__{ref: ref},
         feature_names,
         %Optify.GetOptionsPreferences{ref: prefs_ref}
-      ) do
+      )
+      when is_list(feature_names) do
     Optify.Native.watcher_get_filtered_feature_names(ref, feature_names, prefs_ref)
   end
 
@@ -131,7 +139,8 @@ defmodule Optify.OptionsWatcher do
 
   def map_feature_names(%__MODULE__{ref: ref}, feature_names, %Optify.GetOptionsPreferences{
         ref: prefs_ref
-      }) do
+      })
+      when is_list(feature_names) do
     Optify.Native.watcher_map_feature_names(ref, feature_names, prefs_ref)
   end
 
@@ -140,7 +149,8 @@ defmodule Optify.OptionsWatcher do
     map_feature_names(watcher, feature_names, prefs)
   end
 
-  def has_conditions?(%__MODULE__{ref: ref}, canonical_feature_name) do
+  def has_conditions?(%__MODULE__{ref: ref}, canonical_feature_name)
+      when is_binary(canonical_feature_name) do
     Optify.Native.watcher_has_conditions(ref, canonical_feature_name)
   end
 

--- a/elixir/optify/lib/optify/options_watcher_builder.ex
+++ b/elixir/optify/lib/optify/options_watcher_builder.ex
@@ -9,7 +9,7 @@ defmodule Optify.OptionsWatcherBuilder do
     %__MODULE__{ref: Optify.Native.watcher_builder_new()}
   end
 
-  def add_directory(%__MODULE__{ref: ref} = builder, directory) do
+  def add_directory(%__MODULE__{ref: ref} = builder, directory) when is_binary(directory) do
     case Optify.Native.watcher_builder_add_directory(ref, directory) do
       {:ok, _} -> {:ok, builder}
       {:error, _} = err -> err

--- a/elixir/optify/native/optify_nif/src/provider.rs
+++ b/elixir/optify/native/optify_nif/src/provider.rs
@@ -11,7 +11,7 @@ impl rustler::Resource for ProviderResource {}
 
 // ===== Factory =====
 
-#[rustler::nif]
+#[rustler::nif(schedule = "DirtyCpu")]
 pub fn provider_build(directory: String) -> NifResult<ResourceArc<ProviderResource>> {
     match OptionsProvider::build(&directory) {
         Ok(provider) => Ok(ResourceArc::new(ProviderResource(provider))),
@@ -19,7 +19,7 @@ pub fn provider_build(directory: String) -> NifResult<ResourceArc<ProviderResour
     }
 }
 
-#[rustler::nif]
+#[rustler::nif(schedule = "DirtyCpu")]
 pub fn provider_build_with_schema(
     directory: String,
     schema_path: String,
@@ -30,7 +30,7 @@ pub fn provider_build_with_schema(
     }
 }
 
-#[rustler::nif]
+#[rustler::nif(schedule = "DirtyCpu")]
 pub fn provider_build_from_directories(
     directories: Vec<String>,
 ) -> NifResult<ResourceArc<ProviderResource>> {
@@ -40,7 +40,7 @@ pub fn provider_build_from_directories(
     }
 }
 
-#[rustler::nif]
+#[rustler::nif(schedule = "DirtyCpu")]
 pub fn provider_build_from_directories_with_schema(
     directories: Vec<String>,
     schema_path: String,

--- a/elixir/optify/native/optify_nif/src/provider_builder.rs
+++ b/elixir/optify/native/optify_nif/src/provider_builder.rs
@@ -16,7 +16,7 @@ pub fn provider_builder_new() -> ResourceArc<ProviderBuilderResource> {
     )))
 }
 
-#[rustler::nif]
+#[rustler::nif(schedule = "DirtyCpu")]
 pub fn provider_builder_add_directory(
     builder: ResourceArc<ProviderBuilderResource>,
     directory: String,

--- a/elixir/optify/native/optify_nif/src/watcher.rs
+++ b/elixir/optify/native/optify_nif/src/watcher.rs
@@ -12,7 +12,7 @@ impl rustler::Resource for WatcherResource {}
 
 // ===== Factory =====
 
-#[rustler::nif]
+#[rustler::nif(schedule = "DirtyCpu")]
 pub fn watcher_build(directory: String) -> NifResult<ResourceArc<WatcherResource>> {
     match OptionsWatcher::build(&directory) {
         Ok(watcher) => Ok(ResourceArc::new(WatcherResource(Mutex::new(watcher)))),
@@ -20,7 +20,7 @@ pub fn watcher_build(directory: String) -> NifResult<ResourceArc<WatcherResource
     }
 }
 
-#[rustler::nif]
+#[rustler::nif(schedule = "DirtyCpu")]
 pub fn watcher_build_with_schema(
     directory: String,
     schema_path: String,
@@ -31,7 +31,7 @@ pub fn watcher_build_with_schema(
     }
 }
 
-#[rustler::nif]
+#[rustler::nif(schedule = "DirtyCpu")]
 pub fn watcher_build_from_directories(
     directories: Vec<String>,
 ) -> NifResult<ResourceArc<WatcherResource>> {
@@ -41,7 +41,7 @@ pub fn watcher_build_from_directories(
     }
 }
 
-#[rustler::nif]
+#[rustler::nif(schedule = "DirtyCpu")]
 pub fn watcher_build_from_directories_with_schema(
     directories: Vec<String>,
     schema_path: String,

--- a/elixir/optify/native/optify_nif/src/watcher_builder.rs
+++ b/elixir/optify/native/optify_nif/src/watcher_builder.rs
@@ -32,7 +32,7 @@ pub fn watcher_builder_add_directory(
     Ok(builder)
 }
 
-#[rustler::nif]
+#[rustler::nif(schedule = "DirtyCpu")]
 pub fn watcher_builder_build(
     builder: ResourceArc<WatcherBuilderResource>,
 ) -> NifResult<ResourceArc<WatcherResource>> {


### PR DESCRIPTION
NIFs that internally call `add_directory` (which uses rayon's `into_par_iter` for parallel file processing) are now scheduled on dirty CPU scheduler threads via `schedule = "DirtyCpu"`. This prevents them from blocking the normal BEAM schedulers that handle message passing and I/O.