### PR TITLE
[Ruby][CI] Unset Docker tag

### DIFF
--- a/.github/workflows/ruby_build_test.yml
+++ b/.github/workflows/ruby_build_test.yml
@@ -273,7 +273,7 @@ jobs:
         # Docker tag to override the default.
         # Useful when the number is changed for the action, but the Docker image is not yet published.
         # Images: https://hub.docker.com/u/rbsys
-        tag: '0.9.124'
+        # tag: '0.9.124'
         working-directory: ./ruby/optify
 
     - name: "Configure RubyGems credentials"


### PR DESCRIPTION
Remove the hardcoded Docker tag (`0.9.124`) for the `oxidize-rb/actions/cross-gem` action.

The pinned tag became stale as new Ruby patch versions (3.4.9, 3.3.11) were released — the older Docker image lacked `rbconfig` data for those versions, causing the cross-gem build to fail with:
```
no configuration section for specified version of Ruby (rbconfig-x86_64-linux-3.4.9)
Don't know how to build task 'native:x86_64-linux'
```

By unsetting the tag, the action picks its own matching Docker image automatically, keeping it in sync with the resolved Ruby versions from `fetch-ci-data`.