### PR TITLE
[Rust] Use CoW for escaping JSON Pointers

### DIFF
--- a/.github/workflows/elixir_build_test.yml
+++ b/.github/workflows/elixir_build_test.yml
@@ -91,7 +91,7 @@ jobs:
       working-directory: ./elixir/optify
 
     - name: "[Elixir] Compile"
-      run: mix compile --warnings-as-errors
+      run: mix compile --force --warnings-as-errors
       working-directory: ./elixir/optify
 
     - name: "[Elixir] Check formatting"

--- a/elixir/optify/Cargo.lock
+++ b/elixir/optify/Cargo.lock
@@ -167,6 +167,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cow-utils"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "417bef24afe1460300965a25ff4a24b8b45ad011948302ec221e8a0a81eb2c79"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -911,9 +917,10 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "optify"
-version = "1.0.0"
+version = "1.2.0"
 dependencies = [
  "config",
+ "cow-utils",
  "dunce",
  "jsonschema",
  "liquid",

--- a/rust/optify/Cargo.toml
+++ b/rust/optify/Cargo.toml
@@ -19,6 +19,7 @@ exclude = [
 
 [dependencies]
 config = "0.15.23"
+cow-utils = "0.1.3"
 dunce = "1.0.5"
 # HTTP/file schema resolution (`resolve-http`, `resolve-file`) requires a TLS backend.
 # `tls-ring` fails to cross-compile for aarch64; the default `tls-aws-lc-rs` needs cmake/lld unavailable in CI Docker containers.

--- a/rust/optify/README.md
+++ b/rust/optify/README.md
@@ -8,11 +8,55 @@ Simplifies getting the right configuration options for a process using pre-loade
 
 ## Usage
 
-<!-- TODO -->
+Set up your configuration files as explained in the [homepage].
 
-See [tests](../../tests/) for examples and tests for different implementations of this format for managing options.
+Load the configuration directory once when your application starts.
+Use the enabled features for a request or process to get the merged options for a key:
 
-See the root [README.md](../../README.md) for more information and examples.
+```rust
+use optify::provider::OptionsRegistry;
+use optify::OptionsProvider;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct MyConfig {
+    my_array: Vec<String>,
+    my_object: MyObject,
+    root_string: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct MyObject {
+    deeper: Deeper,
+}
+
+#[derive(Debug, Deserialize)]
+struct Deeper {
+    #[serde(rename = "new")]
+    new_value: String,
+}
+
+fn main() -> Result<(), String> {
+    let provider = OptionsProvider::build("path/to/configs")?;
+    let options = provider.get_options("myConfig", &["feature_A", "feature_B/initial"])?;
+    let config: MyConfig = serde_json::from_value(options).map_err(|error| error.to_string())?;
+
+    println!("{}", config.root_string);
+    println!("{}", config.my_array.join(", "));
+    println!("{}", config.my_object.deeper.new_value);
+
+    Ok(())
+}
+```
+
+Use `get_all_options` when you want the full merged options object instead of one key:
+
+```rust
+let options = provider.get_all_options(&["feature_A", "feature_B/initial"], None, None)?;
+```
+
+See [tests] for examples and tests for different implementations of this format for managing options.
 
 ## How It Works
 
@@ -58,4 +102,6 @@ cargo publish
 ```
 
 [config]: https://crates.io/crates/config
+[homepage]: https://github.com/juharris/optify
+[tests]: https://github.com/juharris/optify/tree/main/tests
 [notify-debouncer-full]: https://crates.io/crates/notify-debouncer-full

--- a/rust/optify/README.md
+++ b/rust/optify/README.md
@@ -6,6 +6,10 @@
 The core implementation of Optify in Rust.
 Simplifies getting the right configuration options for a process using pre-loaded configurations from files (JSON, YAML, etc.) to manage options for experiments or flights.
 
+## Usage
+
+<!-- TODO -->
+
 See [tests](../../tests/) for examples and tests for different implementations of this format for managing options.
 
 See the root [README.md](../../README.md) for more information and examples.

--- a/rust/optify/benches/loading_benchmark.rs
+++ b/rust/optify/benches/loading_benchmark.rs
@@ -1,6 +1,8 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use optify::builder::OptionsProviderBuilder;
 use optify::builder::OptionsRegistryBuilder;
+use optify::provider::OptionsRegistry;
+use optify::OptionsProvider;
 use std::fs;
 use std::io::Write;
 use std::path::Path;
@@ -101,14 +103,15 @@ fn benchmark_loading(c: &mut Criterion) {
 
     create_test_files(test_dir, num_files);
 
+    // Ensure that there are no errors.
+    OptionsProvider::build(test_dir).unwrap();
+
     let mut group = c.benchmark_group(format!("loading-{num_files}"));
 
     group.bench_function("parallel loading", |b| {
         b.iter(|| {
             let mut builder = OptionsProviderBuilder::new();
             builder.add_directory(black_box(test_dir)).unwrap();
-            // Ensure that there are no errors in the builder.
-            builder.build().unwrap();
         })
     });
 

--- a/rust/optify/src/configurable_string/locator.rs
+++ b/rust/optify/src/configurable_string/locator.rs
@@ -1,6 +1,6 @@
+use crate::json::escape_json_pointer;
+
 pub(crate) const TYPE_KEY: &str = "$type";
-// TODO Think of a better name. Everything is "configurable".
-// like PrecomputedValue? ConfigurableOption? OptifyOption?
 pub(crate) const TYPE: &str = "Optify.ConfigurableString";
 
 /// Finds pointers like JSON pointers to configurable values
@@ -34,8 +34,7 @@ fn find_configurable_strings_recursive(
 
             // Recursively search object properties
             for (key, val) in obj {
-                // Escape values in the key because "/" needs to be escaped.
-                let key = key.replace("~", "~0").replace("/", "~1");
+                escape_json_pointer!(key);
                 let new_path = if current_pointer.is_empty() {
                     key.to_string()
                 } else {

--- a/rust/optify/src/json/escape_json_pointer.rs
+++ b/rust/optify/src/json/escape_json_pointer.rs
@@ -1,0 +1,9 @@
+macro_rules! escape_json_pointer {
+    ($id:ident) => {
+        use ::cow_utils::CowUtils;
+        let $id = $id.cow_replace("~", "~0");
+        let $id = $id.cow_replace("/", "~1");
+    };
+}
+
+pub(crate) use escape_json_pointer;

--- a/rust/optify/src/json/mod.rs
+++ b/rust/optify/src/json/mod.rs
@@ -1,2 +1,5 @@
+pub(crate) mod escape_json_pointer;
 pub(crate) mod merge;
 pub(crate) mod reader;
+
+pub(crate) use escape_json_pointer::escape_json_pointer;

--- a/rust/optify/src/lib.rs
+++ b/rust/optify/src/lib.rs
@@ -3,3 +3,6 @@ pub mod configurable_string;
 pub(crate) mod json;
 pub mod provider;
 pub mod schema;
+
+pub use provider::OptionsProvider;
+pub use provider::OptionsWatcher;

--- a/rust/optify/src/provider/provider_impl.rs
+++ b/rust/optify/src/provider/provider_impl.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashMap, path::Path, sync::RwLock};
 
 use crate::builder::builder_options::BuilderOptions;
+use crate::json::escape_json_pointer;
 use crate::{
     builder::{OptionsProviderBuilder, OptionsRegistryBuilder},
     configurable_string::LoadedFiles,
@@ -289,7 +290,8 @@ impl OptionsProvider {
         for pointer in &self.all_configurable_value_pointers {
             let relative_pointer = match key_prefix {
                 Some(key_prefix) => {
-                    if !pointer.starts_with(key_prefix) {
+                    escape_json_pointer!(key_prefix);
+                    if !pointer.starts_with(key_prefix.as_ref()) {
                         // The pointer does not start with the key prefix so it will not be used.
                         continue;
                     } else {

--- a/rust/optify/tests/configurable_string_resources/config.json
+++ b/rust/optify/tests/configurable_string_resources/config.json
@@ -1,4 +1,0 @@
-{
-  "version": "1.0.0",
-  "features": ["auth", "api", "database"]
-}

--- a/rust/optify/tests/test_suites.rs
+++ b/rust/optify/tests/test_suites.rs
@@ -1,6 +1,7 @@
 use std::fs;
 
-use optify::provider::{GetOptionsPreferences, OptionsProvider, OptionsRegistry};
+use optify::provider::{GetOptionsPreferences, OptionsRegistry};
+use optify::OptionsProvider;
 
 fn test_suite(path: &std::path::Path) -> Result<(), Box<dyn std::error::Error>> {
     let provider = OptionsProvider::build(path.join("configs"))?;

--- a/scripts/bump_versions.sh
+++ b/scripts/bump_versions.sh
@@ -89,6 +89,8 @@ if grep -Eq '^[[:space:]]*@version[[:space:]]+"' mix.exs; then
 else
     sed_replace_in_place mix.exs "s/version: \"${mix_current}\"/version: \"${mix_next}\"/"
 fi
+# Update Cargo.lock
+mix compile --force
 popd
 
 pushd python/optify

--- a/tests/test_suites/configurable_values/configs/escape_chars.yaml
+++ b/tests/test_suites/configurable_values/configs/escape_chars.yaml
@@ -1,0 +1,6 @@
+options:
+  key~with/escape~chars:
+    arguments~ff/22:
+      ~/`~/``/chars~:
+        $type: Optify.ConfigurableString
+        base: "string"

--- a/tests/test_suites/configurable_values/expectations/escape_chars.json
+++ b/tests/test_suites/configurable_values/expectations/escape_chars.json
@@ -1,0 +1,12 @@
+{
+	"features": [
+		"escape_chars"
+	],
+	"options": {
+		"key~with/escape~chars": {
+			"arguments~ff/22": {
+				"~/`~/``/chars~": "string"
+			}
+		}
+	}
+}


### PR DESCRIPTION
Switch JSON pointer escaping to use `Cow<str>` in order to avoid unnecessary allocations and support both borrowed and owned string inputs.

Loading benchmark: 1-2% faster.

Provider: Add tests for escaping keys

Fix bug: very specific Configurable String edge case: did not handle Configurable Strings if the top-level (first) key had "~" or "/"s.