### PR TITLE
[optimizations] Avoid starts_with checks at the expense of memory

### DIFF
--- a/rust/optify/README.md
+++ b/rust/optify/README.md
@@ -90,6 +90,7 @@ cargo bench
 
 # Run one specific benchmark, example:
 cargo bench --bench get_options_benchmark
+cargo bench --bench get_options_benchmark -- 'get_options/many features'
 
 # Open one of the reports
 open target/criterion/*/report/index.html

--- a/rust/optify/benches/get_options_benchmark.rs
+++ b/rust/optify/benches/get_options_benchmark.rs
@@ -260,18 +260,18 @@ fn benchmark_many_features(c: &mut Criterion) {
         "with_files",
     ];
 
+    let mut preferences = GetOptionsPreferences::new();
+    preferences.are_configurable_strings_enabled = true;
+    let preferences = Some(&preferences);
     for key in keys {
         group.bench_function(key, |b| {
-            let mut preferences = GetOptionsPreferences::new();
-            preferences.are_configurable_strings_enabled = true;
-            let preferences = Some(&preferences);
             b.iter(|| {
                 provider
                     .get_options_with_preferences(
                         black_box(key),
                         black_box(&features),
                         None,
-                        preferences,
+                        black_box(preferences),
                     )
                     .unwrap()
             })

--- a/rust/optify/src/builder/builder_impl.rs
+++ b/rust/optify/src/builder/builder_impl.rs
@@ -371,31 +371,29 @@ impl OptionsProviderBuilder {
 
     fn process_loading_result(
         &mut self,
-        loading_result: &Result<LoadingResult, String>,
+        loading_result: Result<LoadingResult, String>,
     ) -> Result<(), String> {
-        // TODO Move data instead of copying.
-        let info = loading_result.as_ref()?;
+        let info = loading_result?;
         let canonical_feature_name = &info.canonical_feature_name;
 
         if self.schema.is_some() {
-            self.validate_with_schema(info)?;
+            self.validate_with_schema(&info)?;
         }
         if self
             .sources
-            .insert(canonical_feature_name.clone(), info.source.clone())
+            .insert(canonical_feature_name.clone(), info.source)
             .is_some()
         {
             return Err(format!(
                 "Error when loading feature. The canonical feature name '{canonical_feature_name}' was already added. It may be an alias for another feature."
             ));
         }
-        if let Some(conditions) = &info.conditions {
+        if let Some(conditions) = info.conditions {
             self.conditions
-                .insert(canonical_feature_name.clone(), conditions.clone());
+                .insert(canonical_feature_name.clone(), conditions);
         }
-        if let Some(imports) = &info.imports {
-            self.imports
-                .insert(canonical_feature_name.clone(), imports.clone());
+        if let Some(imports) = info.imports {
+            self.imports.insert(canonical_feature_name.clone(), imports);
         }
         self.process_loaded_configurable_value_pointers(&info.configurable_value_pointers);
         for file_key in &info.configurable_string_files {
@@ -409,13 +407,13 @@ impl OptionsProviderBuilder {
             canonical_feature_name,
             canonical_feature_name,
         )?;
-        if let Some(ref aliases) = info.metadata.aliases {
+        if let Some(aliases) = &info.metadata.aliases {
             for alias in aliases {
                 add_alias(&mut self.aliases, alias, canonical_feature_name)?;
             }
         }
         self.features
-            .insert(canonical_feature_name.clone(), info.metadata.clone());
+            .insert(canonical_feature_name.clone(), info.metadata);
         Ok(())
     }
 
@@ -548,7 +546,7 @@ impl OptionsRegistryBuilder<OptionsProvider> for OptionsProviderBuilder {
             })
             .collect();
         for loading_result in loading_results {
-            self.process_loading_result(&loading_result)?;
+            self.process_loading_result(loading_result)?;
         }
 
         Ok(self)

--- a/rust/optify/src/builder/builder_impl.rs
+++ b/rust/optify/src/builder/builder_impl.rs
@@ -31,6 +31,8 @@ pub struct OptionsProviderBuilder {
     aliases: Aliases,
     all_configurable_string_pointers: HashSet<String>,
     all_configurable_list_pointers: HashSet<String>,
+    keyed_configurable_list_pointers: HashMap<String, HashSet<String>>,
+    keyed_configurable_string_pointers: HashMap<String, HashSet<String>>,
     builder_options: BuilderOptions,
     conditions: Conditions,
     dependents: Dependents,
@@ -158,6 +160,8 @@ impl OptionsProviderBuilder {
             aliases: Aliases::new(),
             all_configurable_string_pointers: HashSet::new(),
             all_configurable_list_pointers: HashSet::new(),
+            keyed_configurable_list_pointers: HashMap::new(),
+            keyed_configurable_string_pointers: HashMap::new(),
             builder_options: BuilderOptions::default(),
             conditions: Conditions::new(),
             dependents: Dependents::new(),
@@ -173,16 +177,24 @@ impl OptionsProviderBuilder {
     pub fn build_and_clear(&mut self) -> Result<OptionsProvider, String> {
         self.prepare_build()?;
 
-        let all_configurable_string_pointers = self
-            .all_configurable_string_pointers
-            .iter()
-            .cloned()
-            .collect();
-        let all_configurable_list_pointers = self
-            .all_configurable_list_pointers
-            .iter()
-            .cloned()
-            .collect();
+        let all_configurable_list_pointers =
+            std::mem::take(&mut self.all_configurable_list_pointers)
+                .into_iter()
+                .collect();
+        let all_configurable_string_pointers =
+            std::mem::take(&mut self.all_configurable_string_pointers)
+                .into_iter()
+                .collect();
+        let keyed_configurable_list_pointers =
+            std::mem::take(&mut self.keyed_configurable_list_pointers)
+                .into_iter()
+                .map(|(key, set)| (key, set.into_iter().collect()))
+                .collect();
+        let keyed_configurable_string_pointers =
+            std::mem::take(&mut self.keyed_configurable_string_pointers)
+                .into_iter()
+                .map(|(key, set)| (key, set.into_iter().collect()))
+                .collect();
 
         let referenced_file_to_feature_names = if self.referenced_file_to_feature_names.is_empty() {
             None
@@ -194,8 +206,8 @@ impl OptionsProviderBuilder {
             std::mem::take(&mut self.aliases),
             all_configurable_list_pointers,
             all_configurable_string_pointers,
-            HashMap::new(),
-            HashMap::new(),
+            keyed_configurable_list_pointers,
+            keyed_configurable_string_pointers,
             std::mem::take(&mut self.conditions),
             std::mem::take(&mut self.features),
             referenced_file_to_feature_names,
@@ -324,35 +336,26 @@ impl OptionsProviderBuilder {
             ),
         };
 
-        let (configurable_value_pointers, configurable_string_files) = if builder_options
-            .are_configurable_strings_enabled
-        {
-            let pointers = find_configurable_values(raw_config.get("options"));
+        let (configurable_value_pointers, configurable_string_files) =
+            if builder_options.are_configurable_strings_enabled {
+                let pointers = find_configurable_values(raw_config.get("options"));
 
-            // Tracking file references is usually not enabled in production systems and is mainly for local development,
-            // so we won't complicate `find_configurable_values` and make it also track referenced files.
-            let files = match builder_options.track_file_references {
-                TrackReferenceMode::None => Vec::new(),
-                TrackReferenceMode::ConfigurableStrings => {
-                    extract_configurable_string_files_from_config(
-                        &raw_config,
-                        &pointers.configurable_string_pointers,
-                    )
-                }
-                TrackReferenceMode::KeyName => {
-                    extract_files_from_config(&raw_config, &pointers.configurable_string_pointers)
-                }
+                // Tracking file references is usually not enabled in production systems and is mainly for local development,
+                // so we won't complicate `find_configurable_values` and make it also track referenced files.
+                let files = match builder_options.track_file_references {
+                    TrackReferenceMode::None => Vec::new(),
+                    TrackReferenceMode::ConfigurableStrings => {
+                        extract_configurable_string_files_from_config(
+                            &raw_config,
+                            &pointers.configurable_string_pointers,
+                        )
+                    }
+                    TrackReferenceMode::KeyName => extract_files_from_config(&raw_config),
+                };
+                (pointers, files)
+            } else {
+                (ConfigurableValuePointers::default(), Vec::new())
             };
-            (pointers, files)
-        } else {
-            (
-                ConfigurableValuePointers {
-                    configurable_string_pointers: Vec::new(),
-                    configurable_list_pointers: Vec::new(),
-                },
-                Vec::new(),
-            )
-        };
 
         Ok(LoadingResult {
             canonical_feature_name,
@@ -370,6 +373,7 @@ impl OptionsProviderBuilder {
         &mut self,
         loading_result: &Result<LoadingResult, String>,
     ) -> Result<(), String> {
+        // TODO Move data instead of copying.
         let info = loading_result.as_ref()?;
         let canonical_feature_name = &info.canonical_feature_name;
 
@@ -393,30 +397,7 @@ impl OptionsProviderBuilder {
             self.imports
                 .insert(canonical_feature_name.clone(), imports.clone());
         }
-        if !info
-            .configurable_value_pointers
-            .configurable_string_pointers
-            .is_empty()
-        {
-            self.all_configurable_string_pointers.extend(
-                info.configurable_value_pointers
-                    .configurable_string_pointers
-                    .iter()
-                    .cloned(),
-            );
-        }
-        if !info
-            .configurable_value_pointers
-            .configurable_list_pointers
-            .is_empty()
-        {
-            self.all_configurable_list_pointers.extend(
-                info.configurable_value_pointers
-                    .configurable_list_pointers
-                    .iter()
-                    .cloned(),
-            );
-        }
+        self.process_loaded_configurable_value_pointers(&info.configurable_value_pointers);
         for file_key in &info.configurable_string_files {
             self.referenced_file_to_feature_names
                 .entry(file_key.clone())
@@ -436,6 +417,33 @@ impl OptionsProviderBuilder {
         self.features
             .insert(canonical_feature_name.clone(), info.metadata.clone());
         Ok(())
+    }
+
+    fn process_loaded_configurable_value_pointers(&mut self, pointers: &ConfigurableValuePointers) {
+        if !pointers.configurable_list_pointers.is_empty() {
+            self.all_configurable_list_pointers
+                .extend(pointers.configurable_list_pointers.iter().cloned());
+        }
+        if !pointers.configurable_string_pointers.is_empty() {
+            self.all_configurable_string_pointers
+                .extend(pointers.configurable_string_pointers.iter().cloned());
+        }
+        if !pointers.keyed_configurable_list_pointers.is_empty() {
+            for (key, set) in &pointers.keyed_configurable_list_pointers {
+                self.keyed_configurable_list_pointers
+                    .entry(key.clone())
+                    .and_modify(|dest_set| dest_set.extend(set.clone()))
+                    .or_insert(set.clone());
+            }
+        }
+        if !pointers.keyed_configurable_string_pointers.is_empty() {
+            for (key, set) in &pointers.keyed_configurable_string_pointers {
+                self.keyed_configurable_string_pointers
+                    .entry(key.clone())
+                    .and_modify(|dest_set| dest_set.extend(set.clone()))
+                    .or_insert(set.clone());
+            }
+        }
     }
 }
 
@@ -597,6 +605,16 @@ impl OptionsRegistryBuilder<OptionsProvider> for OptionsProviderBuilder {
             .iter()
             .cloned()
             .collect();
+        let keyed_configurable_list_pointers = self
+            .keyed_configurable_list_pointers
+            .iter()
+            .map(|(key, set)| (key.clone(), set.iter().cloned().collect()))
+            .collect();
+        let keyed_configurable_string_pointers = self
+            .keyed_configurable_string_pointers
+            .iter()
+            .map(|(key, set)| (key.clone(), set.iter().cloned().collect()))
+            .collect();
 
         let referenced_file_to_feature_names = if self.referenced_file_to_feature_names.is_empty() {
             None
@@ -608,8 +626,8 @@ impl OptionsRegistryBuilder<OptionsProvider> for OptionsProviderBuilder {
             self.aliases.clone(),
             all_configurable_list_pointers,
             all_configurable_string_pointers,
-            HashMap::new(),
-            HashMap::new(),
+            keyed_configurable_list_pointers,
+            keyed_configurable_string_pointers,
             self.conditions.clone(),
             self.features.clone(),
             referenced_file_to_feature_names,

--- a/rust/optify/src/builder/builder_impl.rs
+++ b/rust/optify/src/builder/builder_impl.rs
@@ -192,8 +192,10 @@ impl OptionsProviderBuilder {
 
         Ok(OptionsProvider::new(
             std::mem::take(&mut self.aliases),
-            all_configurable_string_pointers,
             all_configurable_list_pointers,
+            all_configurable_string_pointers,
+            HashMap::new(),
+            HashMap::new(),
             std::mem::take(&mut self.conditions),
             std::mem::take(&mut self.features),
             referenced_file_to_feature_names,
@@ -604,8 +606,10 @@ impl OptionsRegistryBuilder<OptionsProvider> for OptionsProviderBuilder {
 
         Ok(OptionsProvider::new(
             self.aliases.clone(),
-            all_configurable_string_pointers,
             all_configurable_list_pointers,
+            all_configurable_string_pointers,
+            HashMap::new(),
+            HashMap::new(),
             self.conditions.clone(),
             self.features.clone(),
             referenced_file_to_feature_names,

--- a/rust/optify/src/builder/builder_impl.rs
+++ b/rust/optify/src/builder/builder_impl.rs
@@ -395,7 +395,7 @@ impl OptionsProviderBuilder {
         if let Some(imports) = info.imports {
             self.imports.insert(canonical_feature_name.clone(), imports);
         }
-        self.process_loaded_configurable_value_pointers(&info.configurable_value_pointers);
+        self.process_loaded_configurable_value_pointers(info.configurable_value_pointers);
         for file_key in &info.configurable_string_files {
             self.referenced_file_to_feature_names
                 .entry(file_key.clone())
@@ -417,29 +417,29 @@ impl OptionsProviderBuilder {
         Ok(())
     }
 
-    fn process_loaded_configurable_value_pointers(&mut self, pointers: &ConfigurableValuePointers) {
+    fn process_loaded_configurable_value_pointers(&mut self, pointers: ConfigurableValuePointers) {
         if !pointers.configurable_list_pointers.is_empty() {
             self.all_configurable_list_pointers
-                .extend(pointers.configurable_list_pointers.iter().cloned());
+                .extend(pointers.configurable_list_pointers);
         }
         if !pointers.configurable_string_pointers.is_empty() {
             self.all_configurable_string_pointers
-                .extend(pointers.configurable_string_pointers.iter().cloned());
+                .extend(pointers.configurable_string_pointers);
         }
         if !pointers.keyed_configurable_list_pointers.is_empty() {
-            for (key, set) in &pointers.keyed_configurable_list_pointers {
+            for (key, keyed_pointers) in pointers.keyed_configurable_list_pointers {
                 self.keyed_configurable_list_pointers
-                    .entry(key.clone())
-                    .and_modify(|dest_set| dest_set.extend(set.clone()))
-                    .or_insert(set.clone());
+                    .entry(key)
+                    .and_modify(|dest_set| dest_set.extend(keyed_pointers.clone()))
+                    .or_insert(keyed_pointers.into_iter().collect());
             }
         }
         if !pointers.keyed_configurable_string_pointers.is_empty() {
-            for (key, set) in &pointers.keyed_configurable_string_pointers {
+            for (key, keyed_pointers) in pointers.keyed_configurable_string_pointers {
                 self.keyed_configurable_string_pointers
-                    .entry(key.clone())
-                    .and_modify(|dest_set| dest_set.extend(set.clone()))
-                    .or_insert(set.clone());
+                    .entry(key)
+                    .and_modify(|dest_set| dest_set.extend(keyed_pointers.clone()))
+                    .or_insert(keyed_pointers.into_iter().collect());
             }
         }
     }

--- a/rust/optify/src/builder/extract_configurable_string_files_from_config.rs
+++ b/rust/optify/src/builder/extract_configurable_string_files_from_config.rs
@@ -11,8 +11,7 @@ pub(crate) fn extract_configurable_string_files_from_config(
     };
 
     for pointer in configurable_value_pointers {
-        let json_pointer = format!("/{}", pointer);
-        if let Some(configurable_value) = options_obj.pointer(&json_pointer) {
+        if let Some(configurable_value) = options_obj.pointer(pointer) {
             if let Ok(cs) = serde_json::from_value::<ConfigurableString>(configurable_value.clone())
             {
                 configurable_string_files.extend(cs.get_referenced_files());

--- a/rust/optify/src/builder/extract_files_from_config.rs
+++ b/rust/optify/src/builder/extract_files_from_config.rs
@@ -19,10 +19,7 @@ fn collect_file_values(value: &serde_json::Value, files: &mut Vec<String>) {
     }
 }
 
-pub(crate) fn extract_files_from_config(
-    raw_config: &serde_json::Value,
-    _configurable_value_pointers: &[String],
-) -> Vec<String> {
+pub(crate) fn extract_files_from_config(raw_config: &serde_json::Value) -> Vec<String> {
     let mut result = Vec::new();
     let options_obj = match raw_config.get("options") {
         Some(v) => v,

--- a/rust/optify/src/configurable_values/locator.rs
+++ b/rust/optify/src/configurable_values/locator.rs
@@ -1,3 +1,5 @@
+use std::collections::{HashMap, HashSet};
+
 use crate::json::escape_json_pointer;
 
 pub(crate) const TYPE_KEY: &str = "$type";
@@ -7,6 +9,25 @@ pub(crate) const LIST_TYPE: &str = "Optify.ConfigurableList";
 pub(crate) struct ConfigurableValuePointers {
     pub configurable_string_pointers: Vec<String>,
     pub configurable_list_pointers: Vec<String>,
+    pub keyed_configurable_list_pointers: HashMap<String, HashSet<String>>,
+    pub keyed_configurable_string_pointers: HashMap<String, HashSet<String>>,
+}
+
+impl Default for ConfigurableValuePointers {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ConfigurableValuePointers {
+    pub fn new() -> Self {
+        ConfigurableValuePointers {
+            configurable_string_pointers: Vec::new(),
+            configurable_list_pointers: Vec::new(),
+            keyed_configurable_list_pointers: HashMap::new(),
+            keyed_configurable_string_pointers: HashMap::new(),
+        }
+    }
 }
 
 /// Finds pointers like JSON pointers to configurable values
@@ -14,21 +35,20 @@ pub(crate) struct ConfigurableValuePointers {
 pub(crate) fn find_configurable_values(
     options: Option<&serde_json::Value>,
 ) -> ConfigurableValuePointers {
-    let mut result = ConfigurableValuePointers {
-        configurable_string_pointers: Vec::new(),
-        configurable_list_pointers: Vec::new(),
-    };
+    let mut result = ConfigurableValuePointers::default();
 
     if let Some(value) = options {
-        find_configurable_values_recursive(value, "", &mut result);
+        find_configurable_values_recursive(value, None, "", "", &mut result);
     }
 
     result
 }
 
-fn find_configurable_values_recursive(
-    value: &serde_json::Value,
+fn find_configurable_values_recursive<'a>(
+    value: &'a serde_json::Value,
+    mut top_level_key: Option<&'a str>,
     current_pointer: &str,
+    current_keyed_pointer: &str,
     result: &mut ConfigurableValuePointers,
 ) {
     match value {
@@ -39,40 +59,81 @@ fn find_configurable_values_recursive(
                     Some(STRING_TYPE) => {
                         result
                             .configurable_string_pointers
-                            .push(current_pointer.to_string());
+                            .push(current_pointer.to_owned());
+                        if let Some(key) = top_level_key {
+                            result
+                                .keyed_configurable_string_pointers
+                                .entry(key.to_owned())
+                                .or_default()
+                                .insert(current_keyed_pointer.to_owned());
+                        }
                         // Do not recurse because configurable strings cannot contain nested configurable values.
                         return;
                     }
                     Some(LIST_TYPE) => {
                         result
                             .configurable_list_pointers
-                            .push(current_pointer.to_string());
+                            .push(current_pointer.to_owned());
+                        if let Some(key) = top_level_key {
+                            result
+                                .keyed_configurable_list_pointers
+                                .entry(key.to_owned())
+                                .or_default()
+                                .insert(current_keyed_pointer.to_owned());
+                        }
                         // Continue recursing because configurable lists can contain nested configurable values such as strings.
                     }
                     _ => {}
                 }
             }
 
-            // Recursively search object properties
+            // Recursively search object properties.
             for (key, val) in obj {
-                escape_json_pointer!(key);
-                let new_path = if current_pointer.is_empty() {
-                    key.to_string()
+                let next_pointer: String;
+                let next_keyed_pointer: String;
+                if current_pointer.is_empty() {
+                    top_level_key = Some(key);
+                    escape_json_pointer!(key);
+                    next_pointer = format!("/{key}");
+                    // FIXME Shouldn't need to make a new string.
+                    next_keyed_pointer = current_keyed_pointer.to_owned();
                 } else {
-                    format!("{current_pointer}/{key}")
+                    escape_json_pointer!(key);
+                    next_pointer = format!("{current_pointer}/{key}");
+                    next_keyed_pointer = format!("{current_keyed_pointer}/{key}");
                 };
-                find_configurable_values_recursive(val, &new_path, result);
+                find_configurable_values_recursive(
+                    val,
+                    top_level_key,
+                    &next_pointer,
+                    &next_keyed_pointer,
+                    result,
+                );
             }
         }
         serde_json::Value::Array(arr) => {
             // Recursively search array elements
             for (index, val) in arr.iter().enumerate() {
-                let new_path = if current_pointer.is_empty() {
-                    format!("{index}")
+                // Assume current_pointer is set.
+                let next_pointer: String;
+                let next_keyed_pointer: String;
+                if current_pointer.is_empty() {
+                    // Shouldn't happen because the top level should not be an array.
+                    top_level_key = Some("$");
+                    next_pointer = format!("/{index}");
+                    // FIXME Shouldn't need to make a new string.
+                    next_keyed_pointer = current_keyed_pointer.to_owned();
                 } else {
-                    format!("{current_pointer}/{index}")
+                    next_pointer = format!("{current_pointer}/{index}");
+                    next_keyed_pointer = format!("{current_keyed_pointer}/{index}");
                 };
-                find_configurable_values_recursive(val, &new_path, result);
+                find_configurable_values_recursive(
+                    val,
+                    top_level_key,
+                    &next_pointer,
+                    &next_keyed_pointer,
+                    result,
+                );
             }
         }
         _ => {
@@ -115,7 +176,7 @@ mod tests {
 
         assert_eq!(
             pointers.configurable_string_pointers,
-            vec!["feature".to_string()]
+            vec!["/feature".to_string()]
         );
     }
 
@@ -137,7 +198,7 @@ mod tests {
 
         assert_eq!(
             pointers.configurable_string_pointers,
-            vec!["nested/deep/value".to_string()]
+            vec!["/nested/deep/value".to_string()]
         );
     }
 
@@ -157,7 +218,7 @@ mod tests {
 
         assert_eq!(
             pointers.configurable_string_pointers,
-            vec!["array/0".to_string()]
+            vec!["/array/0".to_string()]
         );
     }
 
@@ -201,10 +262,10 @@ mod tests {
         assert_eq!(
             pointers.configurable_string_pointers,
             vec![
-                "array/0".to_string(),
-                "array/2".to_string(),
-                "feature".to_string(),
-                "nested/deep/value".to_string()
+                "/array/0".to_string(),
+                "/array/2".to_string(),
+                "/feature".to_string(),
+                "/nested/deep/value".to_string()
             ]
         );
     }
@@ -279,6 +340,15 @@ mod tests {
                             }
                         }
                     }
+                },
+                "s~": {
+                    TYPE_KEY: STRING_TYPE,
+                },
+                "s/c": {
+                    TYPE_KEY: STRING_TYPE,
+                },
+                "s/c~": {
+                    TYPE_KEY: STRING_TYPE,
                 }
             }
         });
@@ -287,7 +357,12 @@ mod tests {
 
         assert_eq!(
             pointers.configurable_string_pointers,
-            vec!["level1/level2/level3/level4/level5".to_string()]
+            vec![
+                "/level1/level2/level3/level4/level5".to_string(),
+                "/level1/s~1c".to_string(),
+                "/level1/s~1c~0".to_string(),
+                "/level1/s~0".to_string(),
+            ]
         );
     }
 
@@ -316,7 +391,10 @@ mod tests {
 
         assert_eq!(
             pointers.configurable_string_pointers,
-            vec!["items/0/0".to_string(), "items/1/nested_object".to_string()]
+            vec![
+                "/items/0/0".to_string(),
+                "/items/1/nested_object".to_string()
+            ]
         );
     }
 
@@ -341,7 +419,7 @@ mod tests {
         // Should only find the top-level configurable string, not the nested one
         assert_eq!(
             pointers.configurable_string_pointers,
-            vec!["feature".to_string()]
+            vec!["/feature".to_string()]
         );
     }
 
@@ -383,9 +461,9 @@ mod tests {
         assert_eq!(
             pointers.configurable_string_pointers,
             vec![
-                "array/0".to_string(),
-                "feature".to_string(),
-                "nested/deep/value".to_string()
+                "/array/0".to_string(),
+                "/feature".to_string(),
+                "/nested/deep/value".to_string()
             ]
         );
     }

--- a/rust/optify/src/configurable_values/locator.rs
+++ b/rust/optify/src/configurable_values/locator.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use crate::json::escape_json_pointer;
 
@@ -9,8 +9,8 @@ pub(crate) const LIST_TYPE: &str = "Optify.ConfigurableList";
 pub(crate) struct ConfigurableValuePointers {
     pub configurable_string_pointers: Vec<String>,
     pub configurable_list_pointers: Vec<String>,
-    pub keyed_configurable_list_pointers: HashMap<String, HashSet<String>>,
-    pub keyed_configurable_string_pointers: HashMap<String, HashSet<String>>,
+    pub keyed_configurable_list_pointers: HashMap<String, Vec<String>>,
+    pub keyed_configurable_string_pointers: HashMap<String, Vec<String>>,
 }
 
 impl Default for ConfigurableValuePointers {
@@ -38,7 +38,7 @@ pub(crate) fn find_configurable_values(
     let mut result = ConfigurableValuePointers::default();
 
     if let Some(value) = options {
-        find_configurable_values_recursive(value, None, "", "", &mut result);
+        find_configurable_values_recursive(value, None, "".to_owned(), "".to_owned(), &mut result);
     }
 
     result
@@ -47,8 +47,8 @@ pub(crate) fn find_configurable_values(
 fn find_configurable_values_recursive<'a>(
     value: &'a serde_json::Value,
     mut top_level_key: Option<&'a str>,
-    current_pointer: &str,
-    current_keyed_pointer: &str,
+    current_pointer: String,
+    current_keyed_pointer: String,
     result: &mut ConfigurableValuePointers,
 ) {
     match value {
@@ -65,7 +65,7 @@ fn find_configurable_values_recursive<'a>(
                                 .keyed_configurable_string_pointers
                                 .entry(key.to_owned())
                                 .or_default()
-                                .insert(current_keyed_pointer.to_owned());
+                                .push(current_keyed_pointer.to_owned());
                         }
                         // Do not recurse because configurable strings cannot contain nested configurable values.
                         return;
@@ -79,7 +79,7 @@ fn find_configurable_values_recursive<'a>(
                                 .keyed_configurable_list_pointers
                                 .entry(key.to_owned())
                                 .or_default()
-                                .insert(current_keyed_pointer.to_owned());
+                                .push(current_keyed_pointer.to_owned());
                         }
                         // Continue recursing because configurable lists can contain nested configurable values such as strings.
                     }
@@ -95,8 +95,7 @@ fn find_configurable_values_recursive<'a>(
                     top_level_key = Some(key);
                     escape_json_pointer!(key);
                     next_pointer = format!("/{key}");
-                    // FIXME Shouldn't need to make a new string.
-                    next_keyed_pointer = current_keyed_pointer.to_owned();
+                    next_keyed_pointer = current_keyed_pointer.clone();
                 } else {
                     escape_json_pointer!(key);
                     next_pointer = format!("{current_pointer}/{key}");
@@ -105,8 +104,8 @@ fn find_configurable_values_recursive<'a>(
                 find_configurable_values_recursive(
                     val,
                     top_level_key,
-                    &next_pointer,
-                    &next_keyed_pointer,
+                    next_pointer,
+                    next_keyed_pointer,
                     result,
                 );
             }
@@ -119,10 +118,10 @@ fn find_configurable_values_recursive<'a>(
                 let next_keyed_pointer: String;
                 if current_pointer.is_empty() {
                     // Shouldn't happen because the top level should not be an array.
+                    // This is not tested.
                     top_level_key = Some("$");
                     next_pointer = format!("/{index}");
-                    // FIXME Shouldn't need to make a new string.
-                    next_keyed_pointer = current_keyed_pointer.to_owned();
+                    next_keyed_pointer = current_keyed_pointer.clone();
                 } else {
                     next_pointer = format!("{current_pointer}/{index}");
                     next_keyed_pointer = format!("{current_keyed_pointer}/{index}");
@@ -130,8 +129,8 @@ fn find_configurable_values_recursive<'a>(
                 find_configurable_values_recursive(
                     val,
                     top_level_key,
-                    &next_pointer,
-                    &next_keyed_pointer,
+                    next_pointer,
+                    next_keyed_pointer,
                     result,
                 );
             }

--- a/rust/optify/src/provider/provider_impl.rs
+++ b/rust/optify/src/provider/provider_impl.rs
@@ -32,8 +32,12 @@ pub(crate) type OptionsCache = HashMap<(String, Vec<String>, bool), serde_json::
 pub struct CacheOptions {}
 
 pub struct OptionsProvider {
-    all_configurable_string_pointers: Vec<String>,
+    // Configurable Values
     all_configurable_list_pointers: Vec<String>,
+    all_configurable_string_pointers: Vec<String>,
+    keyed_configurable_list_pointers: HashMap<String, Vec<String>>,
+    keyed_configurable_string_pointers: HashMap<String, Vec<String>>,
+
     aliases: Aliases,
     conditions: Conditions,
     features: Features,
@@ -54,8 +58,10 @@ impl OptionsProvider {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         aliases: Aliases,
-        all_configurable_string_pointers: Vec<String>,
         all_configurable_list_pointers: Vec<String>,
+        all_configurable_string_pointers: Vec<String>,
+        keyed_configurable_list_pointers: HashMap<String, Vec<String>>,
+        keyed_configurable_string_pointers: HashMap<String, Vec<String>>,
         conditions: Conditions,
         features: Features,
         referenced_file_to_feature_names: Option<ReferencedFileToFeatureNames>,
@@ -63,8 +69,10 @@ impl OptionsProvider {
         sources: Sources,
     ) -> Self {
         OptionsProvider {
-            all_configurable_string_pointers,
             all_configurable_list_pointers,
+            all_configurable_string_pointers,
+            keyed_configurable_list_pointers,
+            keyed_configurable_string_pointers,
             aliases,
             conditions,
             features,
@@ -295,41 +303,52 @@ impl OptionsProvider {
                         pointer[key_prefix.len()..].to_string()
                     }
                 }
-                // There is not key prefix when the entire configuration is requested.
+                // There is no key prefix when the entire configuration is requested.
                 _ => format!("/{}", pointer),
             };
 
-            if let Some(configurable_value) = value.pointer_mut(&relative_pointer) {
-                // Only continue if it has the right indicator property because it may have been overridden.
-                if let Some(type_value) =
-                    configurable_value.get(crate::configurable_values::locator::TYPE_KEY)
-                {
-                    if let Some(type_str) = type_value.as_str() {
-                        if type_str != crate::configurable_values::locator::LIST_TYPE {
-                            continue;
-                        }
-                    } else {
-                        continue;
+            self.handle_configurable_list_pointer(value, pointer, &relative_pointer)?;
+        }
+
+        Ok(())
+    }
+
+    fn handle_configurable_list_pointer(
+        &self,
+        value: &mut serde_json::Value,
+        pointer: &String,
+        relative_pointer: &String,
+    ) -> Result<(), String> {
+        if let Some(configurable_value) = value.pointer_mut(&relative_pointer) {
+            // Only continue if it has the right indicator property because it may have been overridden.
+            if let Some(type_value) =
+                configurable_value.get(crate::configurable_values::locator::TYPE_KEY)
+            {
+                if let Some(type_str) = type_value.as_str() {
+                    if type_str != crate::configurable_values::locator::LIST_TYPE {
+                        return Ok(());
                     }
                 } else {
-                    continue;
+                    return Ok(());
                 }
-
-                let configurable_list: ConfigurableList =
-                    match serde_json::from_value(configurable_value.clone()) {
-                        Ok(cl) => cl,
-                        Err(e) => {
-                            return Err(format!(
-                                "Failed to deserialize ConfigurableList at {}: {}",
-                                pointer, e
-                            ));
-                        }
-                    };
-
-                // Replace the value at the pointer location with the built list.
-                let built_list = configurable_list.build()?;
-                *configurable_value = serde_json::Value::Array(built_list);
+            } else {
+                return Ok(());
             }
+
+            let configurable_list: ConfigurableList =
+                match serde_json::from_value(configurable_value.clone()) {
+                    Ok(cl) => cl,
+                    Err(e) => {
+                        return Err(format!(
+                            "Failed to deserialize ConfigurableList at {}: {}",
+                            pointer, e
+                        ));
+                    }
+                };
+
+            // Replace the value at the pointer location with the built list.
+            let built_list = configurable_list.build()?;
+            *configurable_value = serde_json::Value::Array(built_list);
         }
 
         Ok(())
@@ -353,43 +372,53 @@ impl OptionsProvider {
                         pointer[key_prefix.len()..].to_string()
                     }
                 }
-                // There is not key prefix when the entire configuration is requested.
+                // There is no key prefix when the entire configuration is requested.
                 _ => format!("/{}", pointer),
             };
 
-            if let Some(configurable_value) = value.pointer_mut(&relative_pointer) {
-                // Only continue if it has the right indicator property because it may have been overridden.
-                if let Some(type_value) =
-                    configurable_value.get(crate::configurable_values::locator::TYPE_KEY)
-                {
-                    if let Some(type_str) = type_value.as_str() {
-                        if type_str != crate::configurable_values::locator::STRING_TYPE {
-                            continue;
-                        }
-                    } else {
-                        continue;
-                    }
-                } else {
-                    continue;
-                }
-
-                let configurable_string: ConfigurableString =
-                    match serde_json::from_value(configurable_value.clone()) {
-                        Ok(cs) => cs,
-                        Err(e) => {
-                            return Err(format!(
-                                "Failed to deserialize ConfigurableString at {}: {}",
-                                pointer, e
-                            ));
-                        }
-                    };
-
-                // Replace the value at the pointer location with the built string.
-                let built_string = configurable_string.build(&self.loaded_files)?;
-                *configurable_value = serde_json::Value::String(built_string);
-            }
+            self.handle_configurable_string_pointer(value, pointer, &relative_pointer)?;
         }
 
+        Ok(())
+    }
+
+    fn handle_configurable_string_pointer(
+        &self,
+        value: &mut serde_json::Value,
+        pointer: &String,
+        relative_pointer: &String,
+    ) -> Result<(), String> {
+        if let Some(configurable_value) = value.pointer_mut(relative_pointer) {
+            // Only continue if it has the right indicator property because it may have been overridden.
+            if let Some(type_value) =
+                configurable_value.get(crate::configurable_values::locator::TYPE_KEY)
+            {
+                if let Some(type_str) = type_value.as_str() {
+                    if type_str != crate::configurable_values::locator::STRING_TYPE {
+                        return Ok(());
+                    }
+                } else {
+                    return Ok(());
+                }
+            } else {
+                return Ok(());
+            }
+
+            let configurable_string: ConfigurableString =
+                match serde_json::from_value(configurable_value.clone()) {
+                    Ok(cs) => cs,
+                    Err(e) => {
+                        return Err(format!(
+                            "Failed to deserialize ConfigurableString at {}: {}",
+                            pointer, e
+                        ));
+                    }
+                };
+
+            // Replace the value at the pointer location with the built string.
+            let built_string = configurable_string.build(&self.loaded_files)?;
+            *configurable_value = serde_json::Value::String(built_string);
+        }
         Ok(())
     }
 }

--- a/rust/optify/src/provider/provider_impl.rs
+++ b/rust/optify/src/provider/provider_impl.rs
@@ -2,7 +2,6 @@ use std::{collections::HashMap, path::Path, sync::RwLock};
 
 use crate::builder::builder_options::BuilderOptions;
 use crate::configurable_values::configurable_list_impl::ConfigurableList;
-use crate::json::escape_json_pointer;
 
 use crate::{
     builder::{OptionsProviderBuilder, OptionsRegistryBuilder},
@@ -289,25 +288,25 @@ impl OptionsProvider {
     fn process_configurable_lists(
         &self,
         value: &mut serde_json::Value,
-        key_prefix: Option<&str>,
+        key: Option<&str>,
     ) -> Result<(), String> {
-        for pointer in &self.all_configurable_list_pointers {
-            let relative_pointer = match key_prefix {
-                Some(key_prefix) => {
-                    escape_json_pointer!(key_prefix);
-                    if !pointer.starts_with(key_prefix.as_ref()) {
-                        // The pointer does not start with the key prefix so it will not be used.
-                        continue;
-                    } else {
-                        // Remove the key prefix because we need pointers relative the current key.
-                        pointer[key_prefix.len()..].to_string()
+        match key {
+            Some(key) => match self.keyed_configurable_list_pointers.get(key) {
+                Some(pointers) => {
+                    for pointer in pointers {
+                        self.handle_configurable_list_pointer(value, pointer)?;
                     }
                 }
+                _ => {
+                    // There are no pointers for the key.
+                }
+            },
+            None => {
                 // There is no key prefix when the entire configuration is requested.
-                _ => format!("/{}", pointer),
-            };
-
-            self.handle_configurable_list_pointer(value, pointer, &relative_pointer)?;
+                for pointer in &self.all_configurable_list_pointers {
+                    self.handle_configurable_list_pointer(value, pointer)?;
+                }
+            }
         }
 
         Ok(())
@@ -317,9 +316,8 @@ impl OptionsProvider {
         &self,
         value: &mut serde_json::Value,
         pointer: &String,
-        relative_pointer: &String,
     ) -> Result<(), String> {
-        if let Some(configurable_value) = value.pointer_mut(&relative_pointer) {
+        if let Some(configurable_value) = value.pointer_mut(pointer) {
             // Only continue if it has the right indicator property because it may have been overridden.
             if let Some(type_value) =
                 configurable_value.get(crate::configurable_values::locator::TYPE_KEY)
@@ -358,25 +356,25 @@ impl OptionsProvider {
     fn process_configurable_strings(
         &self,
         value: &mut serde_json::Value,
-        key_prefix: Option<&str>,
+        key: Option<&str>,
     ) -> Result<(), String> {
-        for pointer in &self.all_configurable_string_pointers {
-            let relative_pointer = match key_prefix {
-                Some(key_prefix) => {
-                    escape_json_pointer!(key_prefix);
-                    if !pointer.starts_with(key_prefix.as_ref()) {
-                        // The pointer does not start with the key prefix so it will not be used.
-                        continue;
-                    } else {
-                        // Remove the key prefix because we need pointers relative the current key.
-                        pointer[key_prefix.len()..].to_string()
+        match key {
+            Some(key) => match self.keyed_configurable_string_pointers.get(key) {
+                Some(pointers) => {
+                    for pointer in pointers {
+                        self.handle_configurable_string_pointer(value, pointer)?;
                     }
                 }
+                _ => {
+                    // There are no pointers for the key.
+                }
+            },
+            None => {
                 // There is no key prefix when the entire configuration is requested.
-                _ => format!("/{}", pointer),
-            };
-
-            self.handle_configurable_string_pointer(value, pointer, &relative_pointer)?;
+                for pointer in &self.all_configurable_string_pointers {
+                    self.handle_configurable_string_pointer(value, pointer)?;
+                }
+            }
         }
 
         Ok(())
@@ -386,9 +384,8 @@ impl OptionsProvider {
         &self,
         value: &mut serde_json::Value,
         pointer: &String,
-        relative_pointer: &String,
     ) -> Result<(), String> {
-        if let Some(configurable_value) = value.pointer_mut(relative_pointer) {
+        if let Some(configurable_value) = value.pointer_mut(pointer) {
             // Only continue if it has the right indicator property because it may have been overridden.
             if let Some(type_value) =
                 configurable_value.get(crate::configurable_values::locator::TYPE_KEY)


### PR DESCRIPTION
Avoid `starts_with` checks, at the expense of using more memory to store configurable string pointers by the top level keys.

Move memory more instead of copying.

Resolves #251

`cargo bench --bench loading_benchmark` is 7.5% faster

`cargo bench --bench get_options_benchmark -- 'get_options/many features'`
Is 15-30% faster depending on the key.