### PR TITLE
[fix] Handle merges alternating between objects and primitives

### DIFF
--- a/rust/optify/src/builder/builder_impl.rs
+++ b/rust/optify/src/builder/builder_impl.rs
@@ -14,7 +14,7 @@ use crate::builder::loading_result::LoadingResult;
 use crate::builder::OptionsRegistryBuilder;
 use crate::configurable_string::LoadedFiles;
 use crate::configurable_values::locator::{find_configurable_values, ConfigurableValuePointers};
-use crate::json::merge::merge_json_with_defaults;
+use crate::json::merge::{merge_json_with_defaults, FrozenPaths};
 use crate::json::reader::read_json_from_file_as;
 use crate::provider::{
     Aliases, Conditions, Features, OptionsProvider, ReferencedFileToFeatureNames, Sources,
@@ -81,6 +81,7 @@ fn resolve_imports(
 ) -> Result<(), String> {
     // Build full configuration for the feature so that we don't need to traverse imports for the feature when configurations are requested from the provider.
     let mut merged_config = sources.get(canonical_feature_name).unwrap().clone();
+    let mut frozen_paths = FrozenPaths::new();
     for import in imports_for_feature.iter().rev() {
         // Validate imports.
         if features_in_resolution_path.contains(import) {
@@ -147,7 +148,7 @@ fn resolve_imports(
             }
         }
 
-        merge_json_with_defaults(&mut merged_config, source);
+        merge_json_with_defaults(&mut merged_config, source, &mut frozen_paths);
     }
 
     sources.insert(canonical_feature_name.to_owned(), merged_config);

--- a/rust/optify/src/json/merge.rs
+++ b/rust/optify/src/json/merge.rs
@@ -1,30 +1,87 @@
-/// Merges objects recursively with a target for the right information and defaults to use if the target is missing a value.
+use std::collections::HashSet;
+
+pub(crate) type FrozenPaths = HashSet<String>;
+
+/// Merges objects recursively while remembering paths where lower-priority defaults are blocked.
+/// Merges objects recursively with a target for the correct information
+/// and defaults to use if the target is missing a value.
 /// The `target` is the final value after many merges.
 /// `defaults` has values to use if the `target` is missing a value.
 /// I.e., values in `target` override values in `defaults`.
 /// If a key is missing from `target`, it is copied from `defaults`.
 /// If the key is present in both `target` and `defaults` and the value is an object, the objects are merged recursively.
 #[inline]
-pub fn merge_json_with_defaults(target: &mut serde_json::Value, defaults: &serde_json::Value) {
+pub(crate) fn merge_json_with_defaults(
+    target: &mut serde_json::Value,
+    defaults: &serde_json::Value,
+    frozen_paths: &mut FrozenPaths,
+) {
+    let mut path = String::new();
+    merge_json_with_defaults_at_path(target, defaults, frozen_paths, &mut path);
+}
+
+#[inline]
+fn merge_json_with_defaults_at_path(
+    target: &mut serde_json::Value,
+    defaults: &serde_json::Value,
+    frozen_paths: &mut FrozenPaths,
+    path: &mut String,
+) {
+    if frozen_paths.contains(path.as_str()) {
+        return;
+    }
+
     match (target, defaults) {
         (serde_json::Value::Object(target_map), serde_json::Value::Object(defaults_map)) => {
             for (key, defaults_value) in defaults_map {
+                let previous_path_len = path.len();
+                push_json_pointer_segment(path, key);
+
+                if frozen_paths.contains(path.as_str()) {
+                    path.truncate(previous_path_len);
+                    continue;
+                }
+
                 match target_map.get_mut(key) {
                     Some(target_value) => {
                         // They both have a value for this key.
-                        merge_json_with_defaults(target_value, defaults_value);
+                        merge_json_with_defaults_at_path(
+                            target_value,
+                            defaults_value,
+                            frozen_paths,
+                            path,
+                        );
                     }
                     None => {
                         // Default value is missing from target.
                         target_map.insert(key.clone(), defaults_value.clone());
                     }
                 }
+
+                path.truncate(previous_path_len);
             }
         }
+        (serde_json::Value::Object(_), _) => {
+            // `defaults` is not an object.
+            // A lower-priority primitive would have stopped deeper defaults if it had been the target.
+            // Remember that lower-priority objects cannot add children at this path later.
+            frozen_paths.insert(path.clone());
+        }
         _ => {
-            // Either:
-            // defaults is not an object, but target is already defined so use the target.
-            // target is not an object, so use it as is.
+            // `target` is not an object.
+            // The target already has the winning value at this path.
+            // Defaults only merge through this path when both values are objects.
+        }
+    }
+}
+
+fn push_json_pointer_segment(path: &mut String, key: &str) {
+    path.push('/');
+    for character in key.chars() {
+        match character {
+            '~' => path.push_str("~0"),
+            '/' => path.push_str("~1"),
+            _ => path.push(character),
         }
     }
 }
@@ -34,11 +91,16 @@ mod tests {
     use super::*;
     use serde_json::json;
 
+    fn merge_json(target: &mut serde_json::Value, defaults: &serde_json::Value) {
+        let mut frozen_paths = FrozenPaths::new();
+        merge_json_with_defaults(target, defaults, &mut frozen_paths);
+    }
+
     #[test]
     fn test_merge_with_defaults() {
         let mut target = json!({"a": 1, "b": 2});
         let defaults = json!({"b": 3, "c": 4});
-        merge_json_with_defaults(&mut target, &defaults);
+        merge_json(&mut target, &defaults);
         assert_eq!(target, json!({"a": 1, "b": 2, "c": 4}));
     }
 
@@ -56,7 +118,7 @@ mod tests {
                 "c": 4
             }
         });
-        merge_json_with_defaults(&mut target, &defaults);
+        merge_json(&mut target, &defaults);
         assert_eq!(
             target,
             json!({
@@ -91,7 +153,7 @@ mod tests {
                 }
             }
         });
-        merge_json_with_defaults(&mut target, &defaults);
+        merge_json(&mut target, &defaults);
         assert_eq!(
             target,
             json!({
@@ -112,15 +174,37 @@ mod tests {
     fn test_merge_with_defaults_type_override() {
         let mut target = json!({"key": {"nested": 1}});
         let defaults = json!({"key": "string"});
-        merge_json_with_defaults(&mut target, &defaults);
+        merge_json(&mut target, &defaults);
         assert_eq!(target, json!({"key": {"nested": 1}}));
+    }
+
+    #[test]
+    fn test_merge_with_defaults_using_frozen_paths_blocks_lower_priority_object_defaults() {
+        let mut target = json!({
+            "key/with~special": {
+                "high": true
+            }
+        });
+        let middle_priority_defaults = json!({"key/with~special": false});
+        let low_priority_defaults = json!({
+            "key/with~special": {
+                "low": true
+            }
+        });
+        let mut frozen_paths = FrozenPaths::new();
+
+        merge_json_with_defaults(&mut target, &middle_priority_defaults, &mut frozen_paths);
+        merge_json_with_defaults(&mut target, &low_priority_defaults, &mut frozen_paths);
+
+        assert_eq!(target, json!({"key/with~special": {"high": true}}));
+        assert!(frozen_paths.contains("/key~1with~0special"));
     }
 
     #[test]
     fn test_merge_with_defaults_missing_key() {
         let mut target = json!({"a": 1});
         let defaults = json!({"b": 2});
-        merge_json_with_defaults(&mut target, &defaults);
+        merge_json(&mut target, &defaults);
         assert_eq!(target, json!({"a": 1, "b": 2}));
     }
 
@@ -128,7 +212,7 @@ mod tests {
     fn test_merge_with_defaults_arrays_not_merged() {
         let mut target = json!({"arr": [1, 2, 3]});
         let defaults = json!({"arr": [4, 5]});
-        merge_json_with_defaults(&mut target, &defaults);
+        merge_json(&mut target, &defaults);
         // Target array is preserved, not replaced or merged.
         assert_eq!(target, json!({"arr": [1, 2, 3]}));
     }

--- a/rust/optify/src/json/merge.rs
+++ b/rust/optify/src/json/merge.rs
@@ -37,24 +37,21 @@ fn merge_json_with_defaults_at_path(
                 let previous_path_len = path.len();
                 push_json_pointer_segment(path, key);
 
-                if frozen_paths.contains(path.as_str()) {
-                    path.truncate(previous_path_len);
-                    continue;
-                }
-
-                match target_map.get_mut(key) {
-                    Some(target_value) => {
-                        // They both have a value for this key.
-                        merge_json_with_defaults_at_path(
-                            target_value,
-                            defaults_value,
-                            frozen_paths,
-                            path,
-                        );
-                    }
-                    None => {
-                        // Default value is missing from target.
-                        target_map.insert(key.clone(), defaults_value.clone());
+                if !frozen_paths.contains(path.as_str()) {
+                    match target_map.get_mut(key) {
+                        Some(target_value) => {
+                            // They both have a value for this key.
+                            merge_json_with_defaults_at_path(
+                                target_value,
+                                defaults_value,
+                                frozen_paths,
+                                path,
+                            );
+                        }
+                        None => {
+                            // Default value is missing from target.
+                            target_map.insert(key.clone(), defaults_value.clone());
+                        }
                     }
                 }
 
@@ -64,7 +61,9 @@ fn merge_json_with_defaults_at_path(
         (serde_json::Value::Object(_), _) => {
             // `defaults` is not an object.
             // A lower-priority primitive would have stopped deeper defaults if it had been the target.
-            // Remember that lower-priority objects cannot add children at this path later.
+            // Remember that lower-priority objects cannot add children at this path later
+            // because the default would have overwritten them if we were merge for low to high,
+            // but we merge from high priority to low priority to attempt to copy less.
             frozen_paths.insert(path.clone());
         }
         _ => {

--- a/rust/optify/src/provider/provider_impl.rs
+++ b/rust/optify/src/provider/provider_impl.rs
@@ -6,7 +6,7 @@ use crate::configurable_values::configurable_list_impl::ConfigurableList;
 use crate::{
     builder::{OptionsProviderBuilder, OptionsRegistryBuilder},
     configurable_string::LoadedFiles,
-    json::merge::merge_json_with_defaults,
+    json::merge::{merge_json_with_defaults, FrozenPaths},
     provider::GetOptionsPreferences,
     schema::{conditions::ConditionExpression, metadata::OptionsMetadata},
 };
@@ -133,6 +133,7 @@ impl OptionsProvider {
 
                 // Merge sources as defaults in reverse (highest to lowest priority).
                 // Skip last source if no overrides (already used as base).
+                let mut frozen_paths = FrozenPaths::new();
                 let skip_count = if overrides.is_some() { 0 } else { 1 };
                 for canonical_feature_name in feature_names.iter().rev().skip(skip_count) {
                     let source = self.sources.get(canonical_feature_name).ok_or_else(|| {
@@ -141,7 +142,7 @@ impl OptionsProvider {
                         // It could happen in the future if we allow aliases to be added directly, but we should try to validate them when the provider is built.
                         format!("Feature name {canonical_feature_name:?} is not a known feature.")
                     })?;
-                    merge_json_with_defaults(&mut result, source);
+                    merge_json_with_defaults(&mut result, source, &mut frozen_paths);
                 }
 
                 result
@@ -186,6 +187,7 @@ impl OptionsProvider {
                     // No override. Find first source with key (iterating in reverse = highest priority first).
                     // Use the last source with the key to avoid merging to an empty object.
                     let mut result = None;
+                    let mut frozen_paths = FrozenPaths::new();
                     for canonical_feature_name in filtered_feature_names.iter().rev() {
                         let source = self.sources.get(canonical_feature_name).ok_or_else(|| {
                             format!(
@@ -195,7 +197,11 @@ impl OptionsProvider {
 
                         if let Some(source_value) = source.get(key) {
                             match &mut result {
-                                Some(existing) => merge_json_with_defaults(existing, source_value),
+                                Some(existing) => merge_json_with_defaults(
+                                    existing,
+                                    source_value,
+                                    &mut frozen_paths,
+                                ),
                                 None => result = Some(source_value.clone()),
                             }
                         }
@@ -207,6 +213,7 @@ impl OptionsProvider {
                     // Start with override as base (highest priority).
                     // Sources are ordered from lowest to highest priority, so we iterate in reverse.
                     let mut result = override_value.clone();
+                    let mut frozen_paths = FrozenPaths::new();
                     for canonical_feature_name in filtered_feature_names.iter().rev() {
                         let source = self.sources.get(canonical_feature_name).ok_or_else(|| {
                             format!(
@@ -215,7 +222,7 @@ impl OptionsProvider {
                         })?;
 
                         if let Some(source_value) = source.get(key) {
-                            merge_json_with_defaults(&mut result, source_value);
+                            merge_json_with_defaults(&mut result, source_value, &mut frozen_paths);
                         }
                     }
                     Some(result)

--- a/rust/optify/tests/test_provider.rs
+++ b/rust/optify/tests/test_provider.rs
@@ -2,7 +2,7 @@ use optify::{
     builder::{OptionsProviderBuilder, OptionsRegistryBuilder},
     provider::{GetOptionsPreferences, OptionsProvider, OptionsRegistry},
 };
-use std::sync::OnceLock;
+use std::{fs, sync::OnceLock};
 
 static CONDITIONS_PROVIDER: OnceLock<OptionsProvider> = OnceLock::new();
 static CONFIGURABLE_STRINGS_PROVIDER: OnceLock<OptionsProvider> = OnceLock::new();
@@ -257,6 +257,83 @@ fn test_provider_get_all_options_multiple_features() -> Result<(), Box<dyn std::
         key: opts
     });
     assert_eq!(entire_config, expected);
+    Ok(())
+}
+
+#[test]
+fn test_provider_get_all_options_multiple_features_freezes_primitive_paths(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let temp_dir = tempfile::tempdir()?;
+    fs::write(
+        temp_dir.path().join("low.json"),
+        r#"{
+            "options": {
+                "rootSettings": {
+                    "low": true
+                },
+                "settings": {
+                    "nested": {
+                        "low": true
+                    },
+                    "sibling": "from low"
+                }
+            }
+        }"#,
+    )?;
+    fs::write(
+        temp_dir.path().join("middle.json"),
+        r#"{
+            "options": {
+                "rootSettings": false,
+                "settings": {
+                    "nested": false,
+                    "sibling": "from middle"
+                }
+            }
+        }"#,
+    )?;
+    fs::write(
+        temp_dir.path().join("high.json"),
+        r#"{
+            "options": {
+                "rootSettings": {
+                    "high": true
+                },
+                "settings": {
+                    "nested": {
+                        "high": true
+                    }
+                }
+            }
+        }"#,
+    )?;
+
+    let provider = OptionsProvider::build(temp_dir.path())?;
+    let feature_names = ["low", "middle", "high"];
+    let expected_settings = serde_json::json!({
+        "nested": {
+            "high": true
+        },
+        "sibling": "from middle"
+    });
+    let expected_root_settings = serde_json::json!({
+        "high": true
+    });
+
+    let root_options = provider.get_options("rootSettings", &feature_names)?;
+    let options = provider.get_options("settings", &feature_names)?;
+    let all_options = provider.get_all_options(&feature_names, None, None)?;
+
+    assert_eq!(root_options, expected_root_settings);
+    assert_eq!(options, expected_settings);
+    assert_eq!(
+        all_options,
+        serde_json::json!({
+            "rootSettings": expected_root_settings,
+            "settings": expected_settings
+        })
+    );
+
     Ok(())
 }
 

--- a/tests/test_suites/configurable_values/expectations/simple_raw_override_name.json
+++ b/tests/test_suites/configurable_values/expectations/simple_raw_override_name.json
@@ -1,0 +1,11 @@
+{
+	"features": ["simple", "raw_overrides", "override_name"],
+	"options": {
+		"greeting": "raw greeting",
+		"message": {
+			"arguments": {
+				"name": "space"
+			}
+		}
+	}
+}


### PR DESCRIPTION
Fix issue from https://github.com/juharris/optify/pull/164

Keep the memory and efficiency optimization.
Track frozen paths.

Might not be optimal, but I just wanna get this fix in and then we can optimize later.