### PR TITLE
[extension] Bump to 1.11.1

### DIFF
--- a/vscode/extension/CHANGELOG.md
+++ b/vscode/extension/CHANGELOG.md
@@ -7,7 +7,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## 1.11.1
 
-- Fix: Handle `"areConfigurableValuesEnabled"` in .optify/config.json
+- Hide import graph by default.
+- Optimization: builder: Load raw files in parallel.
+- Fix: Handle `"areConfigurableValuesEnabled"` in `.optify/config.json`.
+- Fix: Handle merges alternating between objects and primitives.
 
 ## 1.11.0
 

--- a/vscode/extension/package-lock.json
+++ b/vscode/extension/package-lock.json
@@ -1,15 +1,15 @@
 {
 	"name": "optify",
-	"version": "1.11.0",
+	"version": "1.11.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "optify",
-			"version": "1.11.0",
+			"version": "1.11.1",
 			"license": "MIT",
 			"dependencies": {
-				"@optify/config": "^1.8.0",
+				"@optify/config": "^1.8.2",
 				"@textea/json-viewer": "^4.0.1",
 				"js-yaml": "^4.1.0",
 				"react": "^18.3.1",
@@ -1917,9 +1917,9 @@
 			}
 		},
 		"node_modules/@optify/config": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/@optify/config/-/config-1.8.0.tgz",
-			"integrity": "sha512-FROLUqLB+MUKnuyuCJCN6ozXzhk12cAaX8xBjtYs7HBhPNR4C6FngEjNaRhtO2DzqPh8MHTtxAslK56fzLT2iA==",
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/@optify/config/-/config-1.8.2.tgz",
+			"integrity": "sha512-sxuUplpfrZ2/cdwGhRcpdkm1NCSWqBkbJQoW/5WowmKBlxe6oI3OsR2svMpmVEWnsCtVXsZszFI1KDpizxIVsw==",
 			"license": "MIT",
 			"dependencies": {
 				"lru-cache": "^11.0.0"
@@ -1928,20 +1928,20 @@
 				"node": ">= 20"
 			},
 			"optionalDependencies": {
-				"@optify/config-darwin-arm64": "1.8.0",
-				"@optify/config-darwin-universal": "1.8.0",
-				"@optify/config-darwin-x64": "1.8.0",
-				"@optify/config-freebsd-x64": "1.8.0",
-				"@optify/config-linux-arm64-gnu": "1.8.0",
-				"@optify/config-linux-arm64-musl": "1.8.0",
-				"@optify/config-linux-x64-gnu": "1.8.0",
-				"@optify/config-win32-x64-msvc": "1.8.0"
+				"@optify/config-darwin-arm64": "1.8.2",
+				"@optify/config-darwin-universal": "1.8.2",
+				"@optify/config-darwin-x64": "1.8.2",
+				"@optify/config-freebsd-x64": "1.8.2",
+				"@optify/config-linux-arm64-gnu": "1.8.2",
+				"@optify/config-linux-arm64-musl": "1.8.2",
+				"@optify/config-linux-x64-gnu": "1.8.2",
+				"@optify/config-win32-x64-msvc": "1.8.2"
 			}
 		},
 		"node_modules/@optify/config-darwin-arm64": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/@optify/config-darwin-arm64/-/config-darwin-arm64-1.8.0.tgz",
-			"integrity": "sha512-T7fxKzeXxcIpuln///DGdx+lvUy+VJ837OwlacD6gBoiMJbND1dYHX+IYc/cm/MLp742+EyMwbG6IcIW2DCa3g==",
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/@optify/config-darwin-arm64/-/config-darwin-arm64-1.8.2.tgz",
+			"integrity": "sha512-PfWUrV1NPnsOVlV2hiww17j1WQYfrSqXc6zion8iOuD/HSEVcVInhV1CwhI7Lr1SxGSSPm4MAQaACSWSppbENg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1955,9 +1955,9 @@
 			}
 		},
 		"node_modules/@optify/config-darwin-universal": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/@optify/config-darwin-universal/-/config-darwin-universal-1.8.0.tgz",
-			"integrity": "sha512-TjZblRccUpYgYLLUw8BJKUENjQ67wIiBJ9AwVL9u/B6DE2Sd/3o38ur9Rf71gA0o3znku0rK7UqtzvnIHCSxVA==",
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/@optify/config-darwin-universal/-/config-darwin-universal-1.8.2.tgz",
+			"integrity": "sha512-lRU/h3vdcdqBHaeRZciwnU3JrJUk2nu+58kjgQtZujMUaX+uU3GYra1faD3DsTPuWDbziVb5Tsk1br7FbQ95Cw==",
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1968,9 +1968,9 @@
 			}
 		},
 		"node_modules/@optify/config-darwin-x64": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/@optify/config-darwin-x64/-/config-darwin-x64-1.8.0.tgz",
-			"integrity": "sha512-/rPZyvhwzUcJt4rAZYKIP6zk/tcO8ouSkvh8Vb7z9SlFCi72QymwpSwwoXytxiAFMcL91WTShgaCN1eGWBfYPw==",
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/@optify/config-darwin-x64/-/config-darwin-x64-1.8.2.tgz",
+			"integrity": "sha512-VYU1gaB1oT6i426ONsW6riuCZ/4PDQY4GQolGv42lG2tkwMusIvFf9yP7WIHBX6VaLK05+Qo74fUSJ6CuuSaiA==",
 			"cpu": [
 				"x64"
 			],
@@ -1984,9 +1984,9 @@
 			}
 		},
 		"node_modules/@optify/config-freebsd-x64": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/@optify/config-freebsd-x64/-/config-freebsd-x64-1.8.0.tgz",
-			"integrity": "sha512-9tHlJiYujdnuW7Gn2envOnlQ/qFMdcO6l9XMOnVS5Lx4QtTTGNDcnW75K4j8yWItitiLGgl22qRY+xwn+nFaVg==",
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/@optify/config-freebsd-x64/-/config-freebsd-x64-1.8.2.tgz",
+			"integrity": "sha512-STW6zXzeiIc5pEcjUPFTs/uC8sldeMNo5+xwaeXfDiCCF+6YlMr9Bh7PJG1WvwUqo0CSPqfY3VXdXGg5YNGswA==",
 			"cpu": [
 				"x64"
 			],
@@ -2000,9 +2000,9 @@
 			}
 		},
 		"node_modules/@optify/config-linux-arm64-gnu": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/@optify/config-linux-arm64-gnu/-/config-linux-arm64-gnu-1.8.0.tgz",
-			"integrity": "sha512-lgfNw3Mcowo2WRoHYh9PPLCTmEdp2eaSrYotv4+/m9z88nEQ0UyZ1kOSXDkXiWONDl90WdT7UywzS+Jqgxw1cA==",
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/@optify/config-linux-arm64-gnu/-/config-linux-arm64-gnu-1.8.2.tgz",
+			"integrity": "sha512-IUfDOOnpLXZcOvA22WK4ksCGM+AFog6oAavZJZeJu7Ja/hf1fWvOQn5f1TYdKKdW9/0wGcUT5euTZhOxp9hN+Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -2016,9 +2016,9 @@
 			}
 		},
 		"node_modules/@optify/config-linux-arm64-musl": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/@optify/config-linux-arm64-musl/-/config-linux-arm64-musl-1.8.0.tgz",
-			"integrity": "sha512-zNHQ8ZpgAy7aTTwzHuBeOx7xr5Cq+vriYZJ4SOjcoF4k7tkxHc00dAoNQ2J1Z23vvqUSSXQuI5kVG9yzg0eRSg==",
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/@optify/config-linux-arm64-musl/-/config-linux-arm64-musl-1.8.2.tgz",
+			"integrity": "sha512-TM41NM8UDjPs0mdgF7mySbSW10+FMg3knZhrunPH7eFXg6x5ybO/ESq7JZQoOmhDNM2L9IGxGQanHNH1/5AvrA==",
 			"cpu": [
 				"arm64"
 			],
@@ -2032,9 +2032,9 @@
 			}
 		},
 		"node_modules/@optify/config-linux-x64-gnu": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/@optify/config-linux-x64-gnu/-/config-linux-x64-gnu-1.8.0.tgz",
-			"integrity": "sha512-VXx5IJtn59rq9z+GP30p+v17r3tI+CoO1oobtid47Y5LJf/jonUZt+yuFTyRrQ1SBWhvZ93kigUAdQGci+rQ3g==",
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/@optify/config-linux-x64-gnu/-/config-linux-x64-gnu-1.8.2.tgz",
+			"integrity": "sha512-0x/RhZDkZf/xLR5CHJGwErPiLKMKl0s0dqE9UQzVOxJpkrYkwrJHwHrb8ftRN3BVen+JdBQ8N6Ld2flSJVdkuw==",
 			"cpu": [
 				"x64"
 			],
@@ -2048,9 +2048,9 @@
 			}
 		},
 		"node_modules/@optify/config-win32-x64-msvc": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/@optify/config-win32-x64-msvc/-/config-win32-x64-msvc-1.8.0.tgz",
-			"integrity": "sha512-daQH8c8MpyPrYv3wPWgfHxaAvoAuxKgawaI4cQ9eAG8yKkCk67HNsja1hIFYAm1JRPiwZPrAZXrlQEdLrpRNkg==",
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/@optify/config-win32-x64-msvc/-/config-win32-x64-msvc-1.8.2.tgz",
+			"integrity": "sha512-qkqYJfxT11jx62gOY5W2QJM+mfMk8Ds1TmsW88GimxMX+bV9nzeyDcZssVbZ3K/FO17Cpgx4an88owE/JzfLrg==",
 			"cpu": [
 				"x64"
 			],

--- a/vscode/extension/package.json
+++ b/vscode/extension/package.json
@@ -2,7 +2,7 @@
 	"name": "optify",
 	"displayName": "Optify",
 	"description": "Helps manage Optify feature files.",
-	"version": "1.11.0",
+	"version": "1.11.1",
 	"publisher": "optify-config",
 	"license": "MIT",
 	"repository": "https://github.com/juharris/optify",
@@ -82,7 +82,7 @@
 		"typescript": "^5.8.3"
 	},
 	"dependencies": {
-		"@optify/config": "^1.8.0",
+		"@optify/config": "^1.8.2",
 		"@textea/json-viewer": "^4.0.1",
 		"js-yaml": "^4.1.0",
 		"react": "^18.3.1",

--- a/vscode/extension/src/webview/PreviewApp.tsx
+++ b/vscode/extension/src/webview/PreviewApp.tsx
@@ -56,10 +56,9 @@ const LoadingIndicator: React.FC<{ label: string }> = ({ label }) => (
 export const PreviewApp: React.FC = () => {
 	const [previewData, setPreviewData] = useState<PreviewData | undefined>(undefined);
 	const [graphData, setGraphData] = useState<FeatureGraphData | undefined>(undefined);
-	const [isConfigLoading, setIsConfigLoading] = useState(true);
 	const [isGraphLoading, setIsGraphLoading] = useState(true);
 	const [theme, setTheme] = useState<'light' | 'dark'>('dark');
-	const [showGraph, setShowGraph] = useState(true);
+	const [showGraph, setShowGraph] = useState(false);
 	const [expandAll, setExpandAll] = useState<boolean | undefined>(true);
 	const [selectedFeatures, setSelectedFeatures] = useState<Array<{ value: string; label: string }>>([]);
 
@@ -76,7 +75,6 @@ export const PreviewApp: React.FC = () => {
 			if (message.type === 'updateConfig') {
 				setPreviewData(message.data);
 				setSelectedFeatures(message.data.features.map(f => ({ value: f, label: f })));
-				setIsConfigLoading(false);
 			} else if (message.type === 'updateGraph') {
 				setGraphData(message.data.graphData);
 				setIsGraphLoading(false);


### PR DESCRIPTION
- Hide import graph by default.
- Optimization: builder: Load raw files in parallel.
- Fix: Handle `"areConfigurableValuesEnabled"` in `.optify/config.json`.
- Fix: Handle merges alternating between objects and primitives.