### PR TITLE
[Ruby] Add Ruby cache event callback

### DIFF
--- a/ruby/optify/.rubocop.yml
+++ b/ruby/optify/.rubocop.yml
@@ -26,7 +26,10 @@ Metrics/CyclomaticComplexity:
   Max: 20
 
 Metrics/MethodLength:
-  Max: 21
+  Max: 22
+
+Metrics/ModuleLength:
+  Max: 105
 
 Metrics/PerceivedComplexity:
   Max: 11

--- a/ruby/optify/lib/optify_ruby/implementation.rb
+++ b/ruby/optify/lib/optify_ruby/implementation.rb
@@ -11,7 +11,6 @@ require_relative './provider_module'
 # Tools for working with configurations declared in files.
 module Optify
   # Options for caching.
-  # Only enabling or disabling caching is supported for now.
   class CacheOptions < FromHashable
     #: (^(Array[untyped] key, untyped value, bool is_cache_hit) -> void)?
     attr_accessor :on_cache_event

--- a/ruby/optify/lib/optify_ruby/implementation.rb
+++ b/ruby/optify/lib/optify_ruby/implementation.rb
@@ -13,6 +13,8 @@ module Optify
   # Options for caching.
   # Only enabling or disabling caching is supported for now.
   class CacheOptions < FromHashable
+    #: (^(Array[untyped] key, untyped value, bool is_cache_hit) -> void)?
+    attr_accessor :on_cache_event
   end
 
   # Provides configurations based on keys and enabled feature names.

--- a/ruby/optify/lib/optify_ruby/provider_module.rb
+++ b/ruby/optify/lib/optify_ruby/provider_module.rb
@@ -9,20 +9,20 @@ module Optify
   # @!visibility private
   module ProviderModule
     #: [T] (LruRedux::Cache | Hash[Array[untyped], T], Array[untyped], (^(Array[untyped] key, T value, bool is_cache_hit) -> void)?) { -> T } -> T
-    def self._cache_getset(cache, cache_key, on_cache_event = nil, &block)
+    def self._cache_getset(cache, cache_key, on_cache_event, &block)
       is_cache_hit = true #: bool
-      if cache.is_a? LruRedux::Cache
-        result = cache.getset(cache_key) do
-          is_cache_hit = false
-          block.call
-        end
-      else
-        # Plain Hash - use fetch with block and store result
-        result = cache.fetch(cache_key) do
-          is_cache_hit = false
-          cache[cache_key] = block.call
-        end
-      end
+      result = if cache.is_a? LruRedux::Cache
+                 cache.getset(cache_key) do
+                   is_cache_hit = false
+                   block.call
+                 end
+               else
+                 # Plain Hash - use fetch with block and store result
+                 cache.fetch(cache_key) do
+                   is_cache_hit = false
+                   cache[cache_key] = block.call
+                 end
+               end
       on_cache_event&.call(cache_key, result, is_cache_hit)
       result
     end
@@ -115,7 +115,7 @@ module Optify
         .from_hash(hash)
     end
 
-    #: [Config] (String key, Array[String] feature_names, Class[Config] config_class, Optify::CacheOptions cache_options, ?Optify::GetOptionsPreferences? preferences) -> Config
+    #: [Config] (String, Array[String], Class[Config], Optify::CacheOptions, ?Optify::GetOptionsPreferences? ) -> Config
     def _get_options_with_cache(key, feature_names, config_class, cache_options, preferences = nil)
       # Cache directly in Ruby instead of Rust because:
       # * Avoid any possible conversion overhead.

--- a/ruby/optify/lib/optify_ruby/provider_module.rb
+++ b/ruby/optify/lib/optify_ruby/provider_module.rb
@@ -8,17 +8,23 @@ require 'sorbet-runtime'
 module Optify
   # @!visibility private
   module ProviderModule
-    #: [T] (LruRedux::Cache | Hash[untyped, untyped], Array[untyped]) { -> T } -> T
-    def self._cache_getset(cache, cache_key, &block)
+    #: [T] (LruRedux::Cache | Hash[Array[untyped], T], Array[untyped], (^(Array[untyped] key, T value, bool is_cache_hit) -> void)?) { -> T } -> T
+    def self._cache_getset(cache, cache_key, on_cache_event = nil, &block)
+      is_cache_hit = true
       if cache.is_a? LruRedux::Cache
-        cache.getset(cache_key, &block)
+        result = cache.getset(cache_key) do
+          is_cache_hit = false
+          block.call
+        end
       else
         # Plain Hash - use fetch with block and store result
-        cache.fetch(cache_key) do
-          result = block.call
-          cache[cache_key] = result
+        result = cache.fetch(cache_key) do
+          is_cache_hit = false
+          cache[cache_key] = block.call
         end
       end
+      on_cache_event&.call(cache_key, result, is_cache_hit)
+      result
     end
 
     #: (CacheInitOptions?) -> ( Hash[Array[untyped], untyped] | LruRedux::Cache)
@@ -109,8 +115,8 @@ module Optify
         .from_hash(hash)
     end
 
-    #: [Config] (String key, Array[String] feature_names, Class[Config] config_class, Optify::CacheOptions _cache_options, ?Optify::GetOptionsPreferences? preferences) -> Config
-    def _get_options_with_cache(key, feature_names, config_class, _cache_options, preferences = nil)
+    #: [Config] (String key, Array[String] feature_names, Class[Config] config_class, Optify::CacheOptions cache_options, ?Optify::GetOptionsPreferences? preferences) -> Config
+    def _get_options_with_cache(key, feature_names, config_class, cache_options, preferences = nil)
       # Cache directly in Ruby instead of Rust because:
       # * Avoid any possible conversion overhead.
       # * Memory management: probably better to do it in Ruby for a Ruby app and avoid memory in Rust.
@@ -133,6 +139,7 @@ module Optify
       ProviderModule._cache_getset(
         @cache, #: as !nil
         cache_key,
+        cache_options.on_cache_event,
       ) do
         # Handle a cache miss.
 

--- a/ruby/optify/lib/optify_ruby/provider_module.rb
+++ b/ruby/optify/lib/optify_ruby/provider_module.rb
@@ -10,7 +10,7 @@ module Optify
   module ProviderModule
     #: [T] (LruRedux::Cache | Hash[Array[untyped], T], Array[untyped], (^(Array[untyped] key, T value, bool is_cache_hit) -> void)?) { -> T } -> T
     def self._cache_getset(cache, cache_key, on_cache_event = nil, &block)
-      is_cache_hit = true
+      is_cache_hit = true #: bool
       if cache.is_a? LruRedux::Cache
         result = cache.getset(cache_key) do
           is_cache_hit = false

--- a/ruby/optify/rbi/optify.rbi
+++ b/ruby/optify/rbi/optify.rbi
@@ -21,6 +21,8 @@ module Optify
   # Options for caching.
   # Only enabling or disabling caching is supported for now.
   class CacheOptions < FromHashable
+    sig { returns(T.nilable(T.proc.params(key: T::Array[T.untyped], value: T.untyped, is_cache_hit: T::Boolean).void)) }
+    attr_accessor :on_cache_event
   end
 
   # The mode for the cache.

--- a/ruby/optify/rbi/optify.rbi
+++ b/ruby/optify/rbi/optify.rbi
@@ -19,10 +19,20 @@ module Optify
   end
 
   # Options for caching.
-  # Only enabling or disabling caching is supported for now.
   class CacheOptions < FromHashable
-    sig { returns(T.nilable(T.proc.params(key: T::Array[T.untyped], value: T.untyped, is_cache_hit: T::Boolean).void)) }
-    attr_accessor :on_cache_event
+    sig do
+      returns(
+        T.nilable(
+          T.proc.params(
+            key: T::Array[T.untyped],
+            value: T.untyped,
+            is_cache_hit: T::Boolean,
+          )
+              .void,
+        ),
+      )
+    end
+    attr_reader :on_cache_event
   end
 
   # The mode for the cache.

--- a/ruby/optify/sig/optify.rbs
+++ b/ruby/optify/sig/optify.rbs
@@ -19,6 +19,11 @@ end
 # Options for caching.
 # Only enabling or disabling caching is supported for now.
 class Optify::CacheOptions < FromHashable
+  attr_accessor on_cache_event: (^(
+    ::Array[untyped] key,
+    untyped value,
+    bool is_cache_hit,
+  ) -> void)?
 end
 
 # The mode for the cache.

--- a/ruby/optify/sig/optify.rbs
+++ b/ruby/optify/sig/optify.rbs
@@ -17,13 +17,7 @@ class Optify::BaseConfig < FromHashable
 end
 
 # Options for caching.
-# Only enabling or disabling caching is supported for now.
 class Optify::CacheOptions < FromHashable
-  attr_accessor on_cache_event: (^(
-    ::Array[untyped] key,
-    untyped value,
-    bool is_cache_hit,
-  ) -> void)?
 end
 
 # The mode for the cache.
@@ -37,7 +31,8 @@ Optify::Optify::CacheMode::THREAD_SAFE: Symbol
 # Options for initializing the cache.
 class Optify::CacheInitOptions
   # A value from `CacheMode`.
-  def initialize: () -> Integer?
+  def initialize: () -> (^(::Array[untyped] key, untyped value, bool is_cache_hit) -> void)?
+                | () -> Integer?
                 | () -> Symbol
                 | (?max_size: Integer? max_size, ?mode: Symbol mode) -> void
 end

--- a/ruby/optify/test/provider_cache_test.rb
+++ b/ruby/optify/test/provider_cache_test.rb
@@ -38,6 +38,32 @@ class ProviderCacheTest < Test::Unit::TestCase
     assert_same(config_a_enabled, config_a2_enabled)
   end
 
+  def test_cache_options_on_cache_event
+    provider = Optify::OptionsProvider
+               .build('../../tests/test_suites/simple/configs')
+               .init
+    events = []
+    cache_options = Optify::CacheOptions.new
+    cache_options.on_cache_event = proc do |cache_key, value, is_cache_hit|
+      events << [cache_key, value, is_cache_hit]
+    end
+
+    config_a = provider.get_options('myConfig', ['A'], MyConfig, cache_options)
+    config_b = provider.get_options('myConfig', ['B'], MyConfig, cache_options)
+    config_a2 = provider.get_options('myConfig', ['A'], MyConfig, cache_options)
+
+    expected_cache_key_a = ['myConfig', ['feature_A'], false, MyConfig]
+    expected_cache_key_b = ['myConfig', ['feature_B/initial'], false, MyConfig]
+    assert_equal(
+      [
+        [expected_cache_key_a, config_a, false],
+        [expected_cache_key_b, config_b, false],
+        [expected_cache_key_a, config_a2, true],
+      ],
+      events,
+    )
+  end
+
   def test_cache_with_constraints
     provider = Optify::OptionsProvider
                .build('../../tests/test_suites/simple/configs')


### PR DESCRIPTION
Add a Ruby on_cache_event callback that takes in the cache key, returned value, and whether the lookup was a cache hit.

Closes https://github.com/juharris/optify/issues/265